### PR TITLE
Lock On

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,86 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &71505372
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Name
+      value: Enemy (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+--- !u!1 &71505373 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 71505372}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &71505374 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 71505372}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &71505375
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71505373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c9236ad839a2af418234fdcfc9cbad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lockOnTransform: {fileID: 1884561765}
 --- !u!1 &78366512
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,6 +513,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195358378}
   m_CullTransparentMesh: 1
+--- !u!1 &199501605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 199501606}
+  m_Layer: 10
+  m_Name: Lock OnTransform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &199501606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 199501605}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.296, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 940673487}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &227297291
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,7 +595,7 @@ MonoBehaviour:
   ignoreLayers:
     serializedVersion: 2
     m_Bits: 0
-  lookSpeed: 0.002
+  lookSpeed: 0.0015
   followSpeed: 0.1
   pivotSpeed: 0.0015
   minimumPivot: -35
@@ -492,6 +603,11 @@ MonoBehaviour:
   cameraSphereRadius: 0.2
   cameraCollisionOffset: 0.2
   minimumCollisionOffset: 0.2
+  currentLockOnTarget: {fileID: 0}
+  nearestLockOnTarget: {fileID: 0}
+  maximumLockOnDistance: 30
+  leftLockTarget: {fileID: 0}
+  rightLockTarget: {fileID: 0}
 --- !u!1 &270672225
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,7 +623,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &270672226
 RectTransform:
   m_ObjectHideFlags: 0
@@ -837,10 +953,10 @@ RectTransform:
   m_Father: {fileID: 1884900738}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 60, y: -228.97835}
+  m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &509421240
 MonoBehaviour:
@@ -1072,10 +1188,10 @@ RectTransform:
   m_Father: {fileID: 1884900738}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 40, y: -108.97835}
+  m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &571249375
 MonoBehaviour:
@@ -6112,6 +6228,37 @@ MonoBehaviour:
   radius: 0.5
   interactableText: Pick Up Item
   weapon: {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
+--- !u!1 &653768482
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 653768483}
+  m_Layer: 12
+  m_Name: Lock On Transform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &653768483
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 653768482}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.274, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1383156161}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &686255777
 GameObject:
   m_ObjectHideFlags: 0
@@ -7288,6 +7435,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1255241893}
   m_CullTransparentMesh: 1
+--- !u!1 &1284610321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1284610322}
+  m_Layer: 12
+  m_Name: Lock On Transform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1284610322
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284610321}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.274, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1735633483}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1367413295
 GameObject:
   m_ObjectHideFlags: 0
@@ -7324,10 +7502,10 @@ RectTransform:
   m_Father: {fileID: 1884900738}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 60, y: -108.97835}
+  m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1367413297
 MonoBehaviour:
@@ -7440,6 +7618,86 @@ MonoBehaviour:
   rightHandSlot2: 1
   leftHandSlot1: 0
   leftHandSlot2: 0
+--- !u!1001 &1383156159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Name
+      value: Enemy (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+--- !u!1 &1383156160 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 1383156159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1383156161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 1383156159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1383156162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1383156160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c9236ad839a2af418234fdcfc9cbad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lockOnTransform: {fileID: 653768483}
 --- !u!1 &1397504206
 GameObject:
   m_ObjectHideFlags: 0
@@ -7552,10 +7810,10 @@ RectTransform:
   m_Father: {fileID: 1884900738}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 40, y: -228.97835}
+  m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1432090120
 MonoBehaviour:
@@ -7860,6 +8118,29 @@ Transform:
   m_Father: {fileID: 227297292}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1735633479 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 1247414621721429469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1735633483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 1247414621721429469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1735633484
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735633479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c9236ad839a2af418234fdcfc9cbad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lockOnTransform: {fileID: 1284610322}
 --- !u!1 &1789143009
 GameObject:
   m_ObjectHideFlags: 0
@@ -8019,7 +8300,31 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1798587347}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 270672225}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 1577174782}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1798587347
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8173,6 +8478,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1863538580}
   m_CullTransparentMesh: 1
+--- !u!1 &1884561764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1884561765}
+  m_Layer: 12
+  m_Name: Lock On Transform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1884561765
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1884561764}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.274, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 71505374}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1884900737
 GameObject:
   m_ObjectHideFlags: 0
@@ -8694,6 +9030,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: lockOnTransform
+      value: 
+      objectReference: {fileID: 199501606}
+    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
       propertyPath: interactableUIGameObject
       value: 
       objectReference: {fileID: 5779780423549578334}
@@ -8761,5 +9101,6 @@ MonoBehaviour:
   hudWindow: {fileID: 2974136226236906644}
   selectWindow: {fileID: 1577174782}
   weaponInventoryWindow: {fileID: 352126586}
+  equipmentWindow: {fileID: 270672225}
   weaponInventorySlotPrefab: {fileID: 846336675}
   weaponInventorySlotsParent: {fileID: 989728988}

--- a/Assets/Scripts/CameraHandler.cs
+++ b/Assets/Scripts/CameraHandler.cs
@@ -36,12 +36,20 @@ namespace sg {
         public float cameraCollisionOffset = 0.2f;
         public float minimumCollisionOffset = 0.2f;
 
+        public Transform currentLockOnTarget;
+        List<CharacterManager> availableTargets = new List<CharacterManager>();
+        public Transform nearestLockOnTarget;
+        public float maximumLockOnDistance = 30f;
+        public Transform leftLockTarget, rightLockTarget;
+
+        InputHandler inputHandler;
         private void Awake() {
             singleton = this;
             myTransform = transform;
             defaultPosition = cameraTransform.localPosition.z;
             ignoreLayers = ~(1 << 8 | 1 << 9 | 1 << 10);
             targetTransform = FindObjectOfType<PlayerManager>().transform;
+            inputHandler = FindObjectOfType<InputHandler>();
         }
 
         // 카메라가 대상을 따라가도록 하는 함수
@@ -60,26 +68,51 @@ namespace sg {
         }
 
         /*
-         * 카메라 회전
+         * 카메라 회전(구면 좌표계인듯?)
          * @delta - FixeddeltaTime
          * @mousXInput - 마우스 좌우 회전값
          * @mouseYInput - 마우스 상하 회전값
          */
         public void HandleCameraRotation(float delta, float mouseXInput, float mouseYInput) {
-            // 시간에 따른 각각의 회전값 변화량을 대입
-            lookAngle += (mouseXInput * lookSpeed) / delta; 
-            pivotAngle -= (mouseYInput * pivotSpeed) / delta;
-            pivotAngle = Mathf.Clamp(pivotAngle, minimumPivot, maximumPivot);
+            // 록온을 하지 않았을 경우
+            if (!inputHandler.lockOnFlag && currentLockOnTarget == null) {
+                // 시간에 따른 각각의 회전값 변화량을 대입
+                lookAngle += (mouseXInput * lookSpeed) / delta; // 좌우 앵글
+                pivotAngle -= (mouseYInput * pivotSpeed) / delta; // 상하 앵글
+                pivotAngle = Mathf.Clamp(pivotAngle, minimumPivot, maximumPivot);
 
-            Vector3 rotation = Vector3.zero; // Euler Angle 값을 저장할 변수 생성
-            rotation.y = lookAngle; // Euler Angle의 y 값에 마우스 좌우 회전값을 대입해준다.
-            Quaternion targetRotation = Quaternion.Euler(rotation); // Quaternion으로 변환
-            myTransform.rotation = targetRotation; // 카메라 회전값을 Quaternion으로 만든다.
-            
-            rotation = Vector3.zero;
-            rotation.x = pivotAngle;
-            targetRotation = Quaternion.Euler(rotation);
-            cameraPivotTransform.localRotation = targetRotation;
+                Vector3 rotation = Vector3.zero; // Euler Angle 값을 저장할 변수 생성
+                rotation.y = lookAngle; // Euler Angle의 y 값에 마우스 좌우 회전값을 대입해준다.
+                Quaternion targetRotation = Quaternion.Euler(rotation); // 목표 회전값(Quaternion)
+                myTransform.rotation = targetRotation; // 카메라 회전값을 목표 회전값으로 만듬
+
+                rotation = Vector3.zero;
+                rotation.x = pivotAngle;
+                targetRotation = Quaternion.Euler(rotation);
+                cameraPivotTransform.localRotation = targetRotation;
+            }
+            // 록온을 했을 경우
+            else {
+                // 카메라가 록온한 대상을 정면으로 바라보며 수평회전하도록 한다.
+                Vector3 dir = currentLockOnTarget.position - transform.position;
+                dir.Normalize();
+                dir.y = 0;
+
+                Quaternion targetRotation = Quaternion.LookRotation(dir); // 대상을 바라보게끔 Quaternion 설정
+                transform.rotation = targetRotation;
+
+                // transform.rotation은 y축 회전값의 변화만 생김
+                // 카메라 피벗의 회전값을 위 회전값과 똑같이 맞춰줌
+                // 카메라 피벗의 회전값을 설정해주지 않으면, 록온 직전의 카메라 수직 회전값에 따라 록온 시점이 변함
+                cameraPivotTransform.rotation = targetRotation;
+                
+                //dir = currentLockOnTarget.position - cameraPivotTransform.position;
+                //dir.Normalize();
+                //targetRotation = Quaternion.LookRotation(dir);
+                //Vector3 eulerAngle = targetRotation.eulerAngles;
+                //eulerAngle.y = 0;
+                //cameraPivotTransform.localEulerAngles = eulerAngle;
+            }
         }
 
         // 카메라가 다른 물체와 충돌할 경우 해결하는 함수
@@ -110,6 +143,70 @@ namespace sg {
             //Debug.Log("카메라 이동거리" + targetPosition);
             cameraTransformPosition.z = Mathf.Lerp(cameraTransform.localPosition.z, targetPosition, delta / 0.2f);
             cameraTransform.localPosition = cameraTransformPosition;
+        }
+
+        public void HandleLockOn() {
+
+            float shortestDistance = Mathf.Infinity;
+            float shortestDistanceOfLeftTarget = Mathf.Infinity;
+            float shortestDistanceOfRightTarget = Mathf.Infinity;
+
+            Collider[] colliders = Physics.OverlapSphere(targetTransform.position, 26);
+
+            // 감지한 Collider들로부터 CharacterManager 스크립트를 가져온다.
+            for (int i = 0; i < colliders.Length; i++) {
+                CharacterManager character = colliders[i].GetComponent<CharacterManager>();
+
+                // 해당 스크립트가 존재한다면
+                if (character != null) {
+                    Vector3 lockTargetDirection = character.transform.position - targetTransform.position;
+                    float distanceFromTarget = Vector3.Distance(targetTransform.position, character.transform.position);
+
+                    // 록온을 했을시의 시야각. 화면 밖에있는 대상은 록온이 안되도록한다.
+                    float viewableAngle = Vector3.Angle(lockTargetDirection, cameraTransform.forward);
+
+                    // 자기 자신에게는 록온이 안되도록 한다.
+                    if (character.transform.root != targetTransform.transform.root && viewableAngle > -50 && viewableAngle < 50 && distanceFromTarget <= maximumLockOnDistance) {
+                        availableTargets.Add(character);
+                    }
+                }
+            }
+
+            for (int i = 0; i < availableTargets.Count; i++) {
+                float distanceFromTarget = Vector3.Distance(targetTransform.position, availableTargets[i].transform.position);
+                if (distanceFromTarget < shortestDistance) {
+                    shortestDistance = distanceFromTarget;
+                    nearestLockOnTarget = availableTargets[i].lockOnTransform;
+                }
+                if (inputHandler.lockOnFlag) { // 록온 상태
+                    // 적도 플레이어를 록온한 상태에서 마주보고 있다는 상황을 가정한듯
+                    // InverseTransformPoint : 객체의 월드좌표를 로컬좌표로 변환
+                    // 현재 록온 되어있는 오브젝트의 로컬좌표계 내에서 다른 록온 가능한 오브젝트들의 상대좌표를 구한다.
+                    Vector3 relativeEnemyPosition = currentLockOnTarget.InverseTransformPoint(availableTargets[i].transform.position);
+                    // 현재 록온되어있는 오브젝트와 다른 오브젝트 사이의 x축 거리
+                    var distanceFromLeftTarget = currentLockOnTarget.transform.position.x - availableTargets[i].transform.position.x;
+                    var distanceFromRightTarget = currentLockOnTarget.transform.position.x + availableTargets[i].transform.position.x;
+
+                    // 상대 좌표의 x 좌표가 양수라면 록온된 오브젝트의 기준으로 오른쪽 : 플레이어 기준으로 왼쪽
+                    if (relativeEnemyPosition.x > 0.00 && distanceFromLeftTarget < shortestDistanceOfLeftTarget) {
+                        shortestDistanceOfLeftTarget = distanceFromLeftTarget;
+                        // 현재 록온된 오브젝트와 가장 가까운 거리를 가진 왼쪽 오브젝트를 저장
+                        leftLockTarget = availableTargets[i].lockOnTransform;
+                    }
+
+                    // 상대 좌표의 x 좌표가 음수라면 록온된 오브젝트의 기준으로 왼쪽에 : 플레이어를 기준으로 오른쪽
+                    if (relativeEnemyPosition.x < 0.00 && distanceFromRightTarget < shortestDistanceOfRightTarget) {
+                        shortestDistanceOfRightTarget = distanceFromRightTarget;
+                        // 현재 록온된 오브젝트와 가장 가까운 거리를 가진 오른쪽 오브젝트를 저장
+                        rightLockTarget = availableTargets[i].lockOnTransform;
+                    }
+                }
+            }
+        }
+        public void ClearLockOnTargets() {
+            availableTargets.Clear();
+            nearestLockOnTarget = null;
+            currentLockOnTarget = null;
         }
     }
 }

--- a/Assets/Scripts/CharacterManager.cs
+++ b/Assets/Scripts/CharacterManager.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace sg {
+    public class CharacterManager : MonoBehaviour {
+        public Transform lockOnTransform;
+    }
+}

--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace sg {
+    public class EnemyManager : CharacterManager {
+        
+    }
+}

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -131,6 +131,15 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             ""id"": ""6e011304-7140-418d-959f-4a22e6c85c9a"",
             ""actions"": [
                 {
+                    ""name"": ""LockOn"",
+                    ""type"": ""Button"",
+                    ""id"": ""33e9c373-0e69-41aa-af71-1a89e2bf70da"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
                     ""name"": ""Roll"",
                     ""type"": ""Button"",
                     ""id"": ""196fcab0-7a6d-4d06-a854-1f665525a90e"",
@@ -215,6 +224,24 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""name"": ""Inventory"",
                     ""type"": ""Button"",
                     ""id"": ""7ad06337-3c66-4228-8cce-927df9213491"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""LockOnTargetLeft"",
+                    ""type"": ""Button"",
+                    ""id"": ""0666c68f-4bb6-40c5-9ea2-2c89999d94f7"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""LockOnTargetRight"",
+                    ""type"": ""Button"",
+                    ""id"": ""076e5f3f-bfa3-4c4e-b2b6-99658087ad20"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
                     ""interactions"": """",
@@ -408,6 +435,61 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""action"": ""Inventory"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""7e8e07d4-8288-4c1a-ab63-bf804b482026"",
+                    ""path"": ""<Keyboard>/q"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""LockOn"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""3f24cbaf-6635-4a47-ae47-e9018e171994"",
+                    ""path"": ""<Gamepad>/rightStick/left"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""LockOnTargetLeft"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""5edaee48-4e23-406f-ba5a-a6c4989391ba"",
+                    ""path"": ""<Keyboard>/1"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""LockOnTargetLeft"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""90278c47-9500-405d-b548-e211fe245e88"",
+                    ""path"": ""<Gamepad>/rightStick/right"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""LockOnTargetRight"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""c687b28e-d986-472b-a964-df9da0d5d81b"",
+                    ""path"": ""<Keyboard>/2"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""LockOnTargetRight"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         }
@@ -420,6 +502,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         m_PlayerMovement_Camera = m_PlayerMovement.FindAction("Camera", throwIfNotFound: true);
         // Player Actions
         m_PlayerActions = asset.FindActionMap("Player Actions", throwIfNotFound: true);
+        m_PlayerActions_LockOn = m_PlayerActions.FindAction("LockOn", throwIfNotFound: true);
         m_PlayerActions_Roll = m_PlayerActions.FindAction("Roll", throwIfNotFound: true);
         m_PlayerActions_RB = m_PlayerActions.FindAction("RB", throwIfNotFound: true);
         m_PlayerActions_RT = m_PlayerActions.FindAction("RT", throwIfNotFound: true);
@@ -430,6 +513,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         m_PlayerActions_Abutton = m_PlayerActions.FindAction("A-button", throwIfNotFound: true);
         m_PlayerActions_Jump = m_PlayerActions.FindAction("Jump", throwIfNotFound: true);
         m_PlayerActions_Inventory = m_PlayerActions.FindAction("Inventory", throwIfNotFound: true);
+        m_PlayerActions_LockOnTargetLeft = m_PlayerActions.FindAction("LockOnTargetLeft", throwIfNotFound: true);
+        m_PlayerActions_LockOnTargetRight = m_PlayerActions.FindAction("LockOnTargetRight", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -545,6 +630,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     // Player Actions
     private readonly InputActionMap m_PlayerActions;
     private List<IPlayerActionsActions> m_PlayerActionsActionsCallbackInterfaces = new List<IPlayerActionsActions>();
+    private readonly InputAction m_PlayerActions_LockOn;
     private readonly InputAction m_PlayerActions_Roll;
     private readonly InputAction m_PlayerActions_RB;
     private readonly InputAction m_PlayerActions_RT;
@@ -555,10 +641,13 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     private readonly InputAction m_PlayerActions_Abutton;
     private readonly InputAction m_PlayerActions_Jump;
     private readonly InputAction m_PlayerActions_Inventory;
+    private readonly InputAction m_PlayerActions_LockOnTargetLeft;
+    private readonly InputAction m_PlayerActions_LockOnTargetRight;
     public struct PlayerActionsActions
     {
         private @PlayerControls m_Wrapper;
         public PlayerActionsActions(@PlayerControls wrapper) { m_Wrapper = wrapper; }
+        public InputAction @LockOn => m_Wrapper.m_PlayerActions_LockOn;
         public InputAction @Roll => m_Wrapper.m_PlayerActions_Roll;
         public InputAction @RB => m_Wrapper.m_PlayerActions_RB;
         public InputAction @RT => m_Wrapper.m_PlayerActions_RT;
@@ -569,6 +658,8 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         public InputAction @Abutton => m_Wrapper.m_PlayerActions_Abutton;
         public InputAction @Jump => m_Wrapper.m_PlayerActions_Jump;
         public InputAction @Inventory => m_Wrapper.m_PlayerActions_Inventory;
+        public InputAction @LockOnTargetLeft => m_Wrapper.m_PlayerActions_LockOnTargetLeft;
+        public InputAction @LockOnTargetRight => m_Wrapper.m_PlayerActions_LockOnTargetRight;
         public InputActionMap Get() { return m_Wrapper.m_PlayerActions; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -578,6 +669,9 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         {
             if (instance == null || m_Wrapper.m_PlayerActionsActionsCallbackInterfaces.Contains(instance)) return;
             m_Wrapper.m_PlayerActionsActionsCallbackInterfaces.Add(instance);
+            @LockOn.started += instance.OnLockOn;
+            @LockOn.performed += instance.OnLockOn;
+            @LockOn.canceled += instance.OnLockOn;
             @Roll.started += instance.OnRoll;
             @Roll.performed += instance.OnRoll;
             @Roll.canceled += instance.OnRoll;
@@ -608,10 +702,19 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Inventory.started += instance.OnInventory;
             @Inventory.performed += instance.OnInventory;
             @Inventory.canceled += instance.OnInventory;
+            @LockOnTargetLeft.started += instance.OnLockOnTargetLeft;
+            @LockOnTargetLeft.performed += instance.OnLockOnTargetLeft;
+            @LockOnTargetLeft.canceled += instance.OnLockOnTargetLeft;
+            @LockOnTargetRight.started += instance.OnLockOnTargetRight;
+            @LockOnTargetRight.performed += instance.OnLockOnTargetRight;
+            @LockOnTargetRight.canceled += instance.OnLockOnTargetRight;
         }
 
         private void UnregisterCallbacks(IPlayerActionsActions instance)
         {
+            @LockOn.started -= instance.OnLockOn;
+            @LockOn.performed -= instance.OnLockOn;
+            @LockOn.canceled -= instance.OnLockOn;
             @Roll.started -= instance.OnRoll;
             @Roll.performed -= instance.OnRoll;
             @Roll.canceled -= instance.OnRoll;
@@ -642,6 +745,12 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
             @Inventory.started -= instance.OnInventory;
             @Inventory.performed -= instance.OnInventory;
             @Inventory.canceled -= instance.OnInventory;
+            @LockOnTargetLeft.started -= instance.OnLockOnTargetLeft;
+            @LockOnTargetLeft.performed -= instance.OnLockOnTargetLeft;
+            @LockOnTargetLeft.canceled -= instance.OnLockOnTargetLeft;
+            @LockOnTargetRight.started -= instance.OnLockOnTargetRight;
+            @LockOnTargetRight.performed -= instance.OnLockOnTargetRight;
+            @LockOnTargetRight.canceled -= instance.OnLockOnTargetRight;
         }
 
         public void RemoveCallbacks(IPlayerActionsActions instance)
@@ -666,6 +775,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
     }
     public interface IPlayerActionsActions
     {
+        void OnLockOn(InputAction.CallbackContext context);
         void OnRoll(InputAction.CallbackContext context);
         void OnRB(InputAction.CallbackContext context);
         void OnRT(InputAction.CallbackContext context);
@@ -676,5 +786,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
         void OnAbutton(InputAction.CallbackContext context);
         void OnJump(InputAction.CallbackContext context);
         void OnInventory(InputAction.CallbackContext context);
+        void OnLockOnTargetLeft(InputAction.CallbackContext context);
+        void OnLockOnTargetRight(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Scripts/PlayerControls.inputactions
+++ b/Assets/Scripts/PlayerControls.inputactions
@@ -109,6 +109,15 @@
             "id": "6e011304-7140-418d-959f-4a22e6c85c9a",
             "actions": [
                 {
+                    "name": "LockOn",
+                    "type": "Button",
+                    "id": "33e9c373-0e69-41aa-af71-1a89e2bf70da",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Roll",
                     "type": "Button",
                     "id": "196fcab0-7a6d-4d06-a854-1f665525a90e",
@@ -193,6 +202,24 @@
                     "name": "Inventory",
                     "type": "Button",
                     "id": "7ad06337-3c66-4228-8cce-927df9213491",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LockOnTargetLeft",
+                    "type": "Button",
+                    "id": "0666c68f-4bb6-40c5-9ea2-2c89999d94f7",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LockOnTargetRight",
+                    "type": "Button",
+                    "id": "076e5f3f-bfa3-4c4e-b2b6-99658087ad20",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
@@ -384,6 +411,61 @@
                     "processors": "",
                     "groups": "",
                     "action": "Inventory",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7e8e07d4-8288-4c1a-ab63-bf804b482026",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LockOn",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3f24cbaf-6635-4a47-ae47-e9018e171994",
+                    "path": "<Gamepad>/rightStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LockOnTargetLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5edaee48-4e23-406f-ba5a-a6c4989391ba",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LockOnTargetLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "90278c47-9500-405d-b548-e211fe245e88",
+                    "path": "<Gamepad>/rightStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LockOnTargetRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c687b28e-d986-472b-a964-df9da0d5d81b",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LockOnTargetRight",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 // 플레이어의 각종 Flag를 처리한다.
 // 플레이어의 각종 기능들을 연결한다.
 namespace sg {
-    public class PlayerManager : MonoBehaviour {
+    public class PlayerManager : CharacterManager {
         InputHandler inputHandler;
         Animator anim;
         public bool isInteracting;

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -12,6 +12,7 @@ namespace sg {
         public GameObject hudWindow;
         public GameObject selectWindow;
         public GameObject weaponInventoryWindow;
+        public GameObject equipmentWindow;
 
         [Header("Weapon Inventory")]
         public GameObject weaponInventorySlotPrefab; // ½½·Ô prefab
@@ -23,7 +24,7 @@ namespace sg {
         }
         private void Start() {
             weaponInventorySlots = weaponInventorySlotsParent.GetComponentsInChildren<WeaponInventorySlot>();
-            equipmentWindowUI.LoadWeaponOnEquipmentScreen(playerInventory);
+            //equipmentWindowUI.LoadWeaponOnEquipmentScreen(playerInventory);
         }
         public void UpdateUI() {
             #region Weapon Inventory Slots
@@ -52,6 +53,7 @@ namespace sg {
 
         public void CloseAllInventoryWindows() {
             weaponInventoryWindow.SetActive(false);
+            equipmentWindow.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
# CharacterManager
- 스크립트 추가
- 후에 EnemyManager, PlayerManager의 부모 클래스로 사용할 것 # PlayerControls
- 록온 관련키 바인딩 추가

#InputHandler
- 록온 버튼 이벤트 추가
- 록온 플래그
- 록온을 현재 대상과 가장 가까운 오른쪽/왼쪽 대상으로 변경하는 버튼 이벤트 추가
- 록온 처리 함수 추가

# CameraHandler
- 기존 항목을 록온을 하지 않았을 경우로 분리
- 록온상태라면 카메라가 플레이어 뒤에서 록온 대상 중심으로 비춘다.
- 록온 대상의 지역좌표계를 이용해 현재 록온된 대상과 근접한 다른 대상들로 록온을 옮길 수 있도록 한다.

# UIManager
- 모든 Window를 닫는 함수에 장비창 추가