### PR TITLE
Fix

### DIFF
--- a/Assets/Scripts/AI/EnemyLocomotionManager.cs
+++ b/Assets/Scripts/AI/EnemyLocomotionManager.cs
@@ -6,7 +6,13 @@ using UnityEngine.AI;
 namespace sg {
     public class EnemyLocomotionManager : MonoBehaviour {
         public LayerMask detectionLayer;
+        public CapsuleCollider characterCollider;
+        public CapsuleCollider characterColliderBlocker;
         private void Awake() {
+        }
+
+        private void Start() {
+            Physics.IgnoreCollision(characterCollider, characterColliderBlocker, true);
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerLocomotion.cs
+++ b/Assets/Scripts/Player/PlayerLocomotion.cs
@@ -15,6 +15,8 @@ namespace sg {
         [HideInInspector]
         public AnimatorHandler animatorHandler;
 
+        public CapsuleCollider characterCollider;
+        public CapsuleCollider characterColliderBlocker;
         public new Rigidbody rigidbody;
         public GameObject normalCamera;
 
@@ -57,6 +59,7 @@ namespace sg {
 
             playerManager.isGrounded = true; // 시작할때는 땅에 착지해있다.
             ignoreForGroundCheck = ~(1 << 8 | 1 << 11); // 착지를 판단할때 무시할 레이어
+            Physics.IgnoreCollision(characterCollider, characterColliderBlocker, true);
         }
 
 


### PR DESCRIPTION
# All States + EnemyManager
- Enemy 게임 오브젝트의 자식으로 빈 오브젝트들을 만들어 각각의 상태로 만들었기 때문에 대상과 방향이나 거리를 구할때 단순히 transform.position이나 transform.rotation을 사용하지 않고 EnemyManager.transform을 사용
- 더이상 EnemyManager에서 대상과의 거리나 방향, 시야각을 다루지 않고 각각의 상태에서 변수로 만들어 사용한다

# Pursue Target State
- 이미 특정 행동중이라면 우선 정지, 다시 Pursue Target State가 된다.
- Player가 Enemy의 공격 사정거리 내에 있음에도 공격이후 뛰면서 Player를 밀어내는걸 방지

# Player + Enemey + EnemyLocomotionManager + PlayerLocomotion
- 서로 충돌이나 밀림현상을 방지하기 위해 빈 게임 오브젝트(Character Collider Blocker)를 자식으로 추가한후 Collider 와 RIgidbody를 추가한다.
- Project Settings 의 Physics에서 충돌하지 않을 레이어들을 설정
- Player 혹은 Enemy의 Collider와 각각의 자식 Character Collider Blocker 의 Collider가 서로 충돌해 공중으로 날아가는 것을 방지하기 위해 충돌하지 않도록 설정한다.