### PR TITLE
Damage + Death

### DIFF
--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -41,6 +41,7 @@ namespace sg {
         UIManager uiManager;
         CameraHandler cameraHandler;
         WeaponSlotManager weaponSlotManager;
+        AnimatorHandler animatorHandler;
         Vector2 movementInput;
         Vector2 cameraInput;
 
@@ -51,6 +52,7 @@ namespace sg {
             uiManager = FindObjectOfType<UIManager>();
             cameraHandler = FindObjectOfType<CameraHandler>();
             weaponSlotManager = GetComponentInChildren<WeaponSlotManager>();
+            animatorHandler = GetComponentInChildren<AnimatorHandler>();
         }
 
         public void OnEnable() {
@@ -127,6 +129,7 @@ namespace sg {
                 } else {
                     if (playerManager.isInteracting) return;
                     if (playerManager.canDoCombo) return;
+                    animatorHandler.anim.SetBool("isUsingRightHand", true);
                     if (playerInventory.currentRightWeaponIndex != -1) {
                         playerAttacker.HandleLightAttack(playerInventory.rightWeapon);
                     } else if (playerInventory.currentRightWeaponIndex == -1) {

--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -18,6 +18,7 @@ namespace sg {
         public bool isInAir;
         public bool isGrounded;
         public bool canDoCombo;
+        public bool isUsingRightHand, isUsingLeftHand;
 
         PlayerLocomotion playerLocomotion;
         CameraHandler cameraHandler;
@@ -39,7 +40,8 @@ namespace sg {
             isInteracting = anim.GetBool("isInteracting");
             canDoCombo = anim.GetBool("canDoCombo");
             anim.SetBool("isInAir", isInAir);
-            
+            isUsingRightHand = anim.GetBool("isUsingRightHand");
+            isUsingLeftHand = anim.GetBool("isUsingLeftHand");
             inputHandler.TickInput(delta);
             // Rigidbody가 이동되는 움직임이 아니라면 일반적인 Update함수에서 호출해도 괜찮다.
             playerLocomotion.HandleRollingAndSprinting(delta);


### PR DESCRIPTION
# States
- 회전 함수를 Attack, Combat Stance 상태에 추가
- Enemy가 Player를 공격하고 엉뚱한 방향으로 회전하지 않도록

# Stats
- 죽은 상태를 관리할 bool형 변수

# WeaponSlotManager
- 공격 모션중 무기와의 충돌을 감지하기 위해 Collider를 열고 닫는 함수를 더이상 오른쪽, 왼쪽으로 구분해놓지 않음
- 대신 bool 형 변수를 통해 오른손 공격과 왼손 공격 구분

# Animator
- 오른손 공격과 왼손 공격을 구분하기 위한 bool 형 매개변수

# PlayerManager + InputHandler
- Animator의 매개변수로 왼손 오른손 공격 여부 판단