### PR TITLE
BackStab

### DIFF
--- a/Assets/Scripts/AI/EnemyManager.cs
+++ b/Assets/Scripts/AI/EnemyManager.cs
@@ -40,9 +40,7 @@ namespace sg {
         private void Update() {
             isInteracting = enemyAnimatorManager.anim.GetBool("isInteracting");
             HandleRecoveryTimer();
-            //Debug.Log("현재 상태 : " + currentState);
-            //Debug.Log(isPerformingAction);
-            //Debug.Log(navmeshAgent.enabled);
+            enemyAnimatorManager.anim.SetBool("isDead", enemyStats.isDead);
         }
 
         private void FixedUpdate() {

--- a/Assets/Scripts/AI/EnemyStats.cs
+++ b/Assets/Scripts/AI/EnemyStats.cs
@@ -19,6 +19,16 @@ namespace sg {
             return maxHealth;
         }
 
+        public void TakeDamageNoAnimation(float damage) {
+            Debug.Log("받은 데미지 : " + damage);
+            currentHealth -= damage;
+            Debug.Log("현재 체력 : " + currentHealth);
+            if (currentHealth <= 0) {
+                currentHealth = 0;
+                isDead = true;
+            }
+        }
+
         public void TakeDamage(float damage) {
             if (isDead) return;
             currentHealth -= damage;

--- a/Assets/Scripts/DamageCollider.cs
+++ b/Assets/Scripts/DamageCollider.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace sg {
     public class DamageCollider : MonoBehaviour {
         Collider damageCollider;
-        public float currentWeaponDamage = 25;
+        public float currentWeaponDamage;
         private void Awake() {
             damageCollider = GetComponent<Collider>();
             damageCollider.gameObject.SetActive(true);

--- a/Assets/Scripts/Items/WeaponItem.cs
+++ b/Assets/Scripts/Items/WeaponItem.cs
@@ -10,6 +10,10 @@ namespace sg {
         public GameObject modelPrefab;
         public bool isUnarmed;
 
+        [Header("Damage")]
+        public float baseDamage = 25;
+        public int criticalDamageMultiplier = 4;
+
         [Header("Idle Animations")]
         public string Right_Hand_Idle;
         public string Left_Hand_Idle;

--- a/Assets/Scripts/Managers/CharacterManager.cs
+++ b/Assets/Scripts/Managers/CharacterManager.cs
@@ -10,5 +10,8 @@ namespace sg {
         [Header("Comabat Colliders")]
         public BoxCollider backStabBoxCollider;
         public BackStabCollider backStabCollider;
+
+        // 데미지는 애니메이션 이벤트로 가해질 것
+        public float pendingCriticalDamage;
     }
 }

--- a/Assets/Scripts/Managers/WeaponSlotManager.cs
+++ b/Assets/Scripts/Managers/WeaponSlotManager.cs
@@ -5,10 +5,13 @@ using UnityEngine;
 namespace sg {
     public class WeaponSlotManager : MonoBehaviour {
         public WeaponItem attackingWeapon;
+        PlayerInventory playerInventory;
         [SerializeField] 
         WeaponHolderSlot leftHandSlot, rightHandSlot, backSlot;
         [SerializeField]
-        DamageCollider leftHandDamageCollider, rightHandDamageCollider;
+        public DamageCollider leftHandDamageCollider; 
+        [SerializeField]
+        public DamageCollider rightHandDamageCollider;
         
         Animator animator;
         QuickSlots quickSlots;
@@ -17,6 +20,7 @@ namespace sg {
         PlayerManager playerManager;
         private void Awake() {
             playerManager = GetComponentInParent<PlayerManager>();
+            playerInventory = GetComponentInParent<PlayerInventory>();
             inputHandler = GetComponentInParent<InputHandler>();
             animator = GetComponent<Animator>();
             quickSlots = FindObjectOfType<QuickSlots>();
@@ -77,13 +81,13 @@ namespace sg {
         #region Handle Weapon's Damage Collider
         // 애니메이션 내의 event로 다음의 함수들을 사용할 것
         private void LoadLeftWeaponDamageCollider() {
-            Debug.Log("왼쪽 무기 콜라이더 로드");
             leftHandDamageCollider = leftHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
+            leftHandDamageCollider.currentWeaponDamage = playerInventory.leftWeapon.baseDamage;
         }
 
         private void LoadRightWeaponDamageCollider() {
-            Debug.Log("오른쪽 무기 콜라이더 로드");
             rightHandDamageCollider = rightHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
+            rightHandDamageCollider.currentWeaponDamage = playerInventory.rightWeapon.baseDamage;
         }
 
         public void OpenDamageCollider() {

--- a/Assets/Scripts/Player/PlayerAttacker.cs
+++ b/Assets/Scripts/Player/PlayerAttacker.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace sg {
     public class PlayerAttacker : MonoBehaviour {
-        AnimatorHandler animatorHandler;
+        PlayerAnimatorManager animatorHandler;
         PlayerInventory playerInventory;
         PlayerManager playerManager;
         InputHandler inputHandler;
@@ -14,7 +14,7 @@ namespace sg {
         LayerMask backStabLayer = 1 << 12;
         
         public void Awake() {
-            animatorHandler = GetComponent<AnimatorHandler>();
+            animatorHandler = GetComponent<PlayerAnimatorManager>();
             playerStats = GetComponentInParent<PlayerStats>();
             playerInventory = GetComponentInParent<PlayerInventory>();
             playerManager = GetComponentInParent<PlayerManager>();
@@ -116,6 +116,7 @@ namespace sg {
             RaycastHit hit;
             if (Physics.Raycast(inputHandler.criticalAttackRayCastStartPoint.position, transform.TransformDirection(Vector3.forward), out hit, 0.5f, backStabLayer)) {
                 CharacterManager enemyCharacterManager = hit.transform.gameObject.GetComponentInParent<CharacterManager>();
+                DamageCollider rightWeapon = weaponSlotManager.rightHandDamageCollider;
                 if (enemyCharacterManager != null) { // 뒤잡, 혹은 앞잡이 가능한 대상을 포착했을 경우
                     // TODO
                     // 피아 식별 (아군이나 자신에게는 가능하지 않도록)
@@ -130,7 +131,10 @@ namespace sg {
                     Quaternion tr = Quaternion.LookRotation(rotationDirection);
                     Quaternion targetRotation = Quaternion.Slerp(playerManager.transform.rotation, tr, 500 * Time.deltaTime);
                     playerManager.transform.rotation = targetRotation;
-                    
+
+                    float criticalDamage = playerInventory.rightWeapon.criticalDamageMultiplier * rightWeapon.currentWeaponDamage;
+                    enemyCharacterManager.pendingCriticalDamage = criticalDamage;
+
                     // 애니메이션 재생
                     animatorHandler.PlayTargetAnimation("Back Stab", true);
                     enemyCharacterManager.GetComponentInChildren<AnimatorManager>().PlayTargetAnimation("Back Stabbed", true);

--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -48,7 +48,7 @@ namespace sg {
             isUsingLeftHand = anim.GetBool("isUsingLeftHand");
             inputHandler.TickInput(delta);
             isInvulnerable = anim.GetBool("isInvulnerable");
-
+            anim.SetBool("isDead", playerStats.isDead);
             // Rigidbody가 이동되는 움직임이 아니라면 일반적인 Update함수에서 호출해도 괜찮다.
             playerLocomotion.HandleRollingAndSprinting(delta);
             playerLocomotion.HandleJumping();

--- a/Assets/Scripts/Player/PlayerStats.cs
+++ b/Assets/Scripts/Player/PlayerStats.cs
@@ -8,12 +8,12 @@ namespace sg {
         StaminaBar staminaBar;
         FocusBar focusBar;
         PlayerManager playerManager;
-        AnimatorHandler animatorHandler;
+        PlayerAnimatorManager animatorHandler;
 
         public float staminaRegenerationAmount = 20;
         public float staminaRegenerationTimer = 0;
         private void Awake() {
-            animatorHandler = GetComponentInChildren<AnimatorHandler>();
+            animatorHandler = GetComponentInChildren<PlayerAnimatorManager>();
             healthBar = FindObjectOfType<HealthBar>();
             staminaBar = FindObjectOfType<StaminaBar>();
             focusBar = FindObjectOfType<FocusBar>();
@@ -46,6 +46,14 @@ namespace sg {
         private float SetMaxStaminaFromStaminaLevel() {
             maxStamina = staminaLevel * 10;
             return maxStamina;
+        }
+
+        public void TakeDamageNoAnimation(float damage) {
+            currentHealth -= damage;
+            if (currentHealth <= 0) {
+                currentHealth = 0;
+                isDead = true;
+            }
         }
 
         public void TakeDamage(float damage) {


### PR DESCRIPTION
# Animator
- bool 매개변수 isDead
- 뒤잡 혹은 앞잡을 당해서 데미지를 전달받을 때, 체력이 다 닳는다면 true
- 기존 사망 애니메이션과 다른 애니메이션을 실행하기 위함

# EnemyManager + PlayerManager
- PlayerStats, EnemyStats의 isDead 변수는 체력이 0이하로 떨어질시 true
- 위 변수를 이용해 Animator의 매개변수 isDead를 제어

# EnemyStats + PlayerStats
- 뒤잡 혹은 앞잡을 당할시 다른 모션을 취하지 않도록 함수 추가

# WeaponItem
- 기본 데미지 + 앞잡, 뒤잡시 데미지 배수

# CharacterManager
- 앞잡, 뒤잡을 당할 시 전달받을 총 데미지를 저장할 변수
- Player, Enemy 상관없이 앞잡, 뒤잡이 가능하므로 부모 클래스에 생성

# WeaponSlotManager
- 양손 무기의 Collider를 로드할 때, DamageCollider가 기본 데미지를 전달받는다.

# PlayerAttacker
- 앞잡, 뒤잡시 데미지는 해당 무기의 DamageCollider로 부터 현재 데미지와 치명타 데미지 배수를 전달받아 결정
- CharacterManager로 전달