### PR TITLE
Fix

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -1090,6 +1090,12 @@ AnimatorController:
   m_Name: Humanoid
   serializedVersion: 5
   m_AnimatorParameters:
+  - m_Name: isInAir
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: isInteracting
     m_Type: 4
     m_DefaultFloat: 0
@@ -1102,7 +1108,7 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: isInAir
+  - m_Name: canRotate
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -1205,6 +1211,20 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!114 &75726583676153412
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b070f41354b9134c9cbac260912c153, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetBool: canRotate
+  status: 1
 --- !u!1102 &805918016173055142
 AnimatorState:
   serializedVersion: 6
@@ -1606,6 +1626,7 @@ AnimatorState:
   - {fileID: 1552241491286241834}
   - {fileID: 7849893155914889298}
   - {fileID: -171783341856858887}
+  - {fileID: 75726583676153412}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -1822,7 +1843,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 4561258091624907548}
-    m_Position: {x: 340, y: -160, z: 0}
+    m_Position: {x: 340, y: -150, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6404699382290321208}
     m_Position: {x: -150, y: -210, z: 0}

--- a/Assets/Art/Animations/OH_Heavy_Attack_1.anim
+++ b/Assets/Art/Animations/OH_Heavy_Attack_1.anim
@@ -107259,6 +107259,20 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
+  - time: 0.33333334
+    functionName: CanRotate
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.8333333
+    functionName: StopRotation
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 1
     functionName: OpenDamageCollider
     data: 

--- a/Assets/Art/Animations/OH_Light_Attack_1.anim
+++ b/Assets/Art/Animations/OH_Light_Attack_1.anim
@@ -56013,6 +56013,20 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
+  - time: 0.3
+    functionName: CanRotate
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.4
+    functionName: StopRotation
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 0.43333334
     functionName: OpenDamageCollider
     data: 

--- a/Assets/Art/Animations/OH_Light_Attack_2.anim
+++ b/Assets/Art/Animations/OH_Light_Attack_2.anim
@@ -64059,6 +64059,20 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
+  - time: 0.43333334
+    functionName: CanRotate
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.6666667
+    functionName: StopRotation
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 0.7
     functionName: OpenDamageCollider
     data: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -12282,6 +12282,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841883, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: rotationSpeed
+      value: 18
+      objectReference: {fileID: 0}
     - target: {fileID: 4086121375157841884, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
       propertyPath: rightWeapon
       value: 

--- a/Assets/Scripts/Managers/AnimatorManager.cs
+++ b/Assets/Scripts/Managers/AnimatorManager.cs
@@ -5,10 +5,12 @@ using UnityEngine;
 namespace sg {
     public class AnimatorManager : MonoBehaviour {
         public Animator anim;
+        public bool canRotate;
 
         // 해당 애니메이션을 실행한다.
         public void PlayTargetAnimation(string targetAnim, bool isInteracting) {
             anim.applyRootMotion = isInteracting;
+            canRotate = false;
             anim.SetBool("isInteracting", isInteracting);
             anim.CrossFade(targetAnim, 0.3f);
         }

--- a/Assets/Scripts/Player/PlayerAnimatorManager.cs
+++ b/Assets/Scripts/Player/PlayerAnimatorManager.cs
@@ -11,7 +11,6 @@ namespace sg {
 
         int vertical;
         int horizontal;
-        public bool canRotate;
         
         public void Initialize() {
             playerManager = GetComponentInParent<PlayerManager>();
@@ -53,10 +52,10 @@ namespace sg {
         }
 
         public void CanRotate() {
-            canRotate = true;
+            anim.SetBool("canRotate", true);
         }
         public void StopRotation() {
-            canRotate = false;
+            anim.SetBool("canRotate", false);
         }
         public void EnableCombo() {
             anim.SetBool("canDoCombo", true);

--- a/Assets/Scripts/Player/PlayerLocomotion.cs
+++ b/Assets/Scripts/Player/PlayerLocomotion.cs
@@ -69,52 +69,54 @@ namespace sg {
         Vector3 targetPosition;
 
         // 캐릭터 회전
-        private void HandleRotation(float delta) {
-            if (inputHandler.lockOnFlag) {
-                // 록온을 해도 달리거나 구를때는, 이동하던 방향으로 행동
-                if (inputHandler.sprintFlag || inputHandler.rollFlag) {
-                    Vector3 targetDirection = Vector3.zero;
-                    targetDirection = cameraHandler.cameraTransform.forward * inputHandler.vertical;
-                    targetDirection += cameraHandler.cameraTransform.right * inputHandler.horizontal;
-                    targetDirection.Normalize();
-                    targetDirection.y = 0;
-                    if (targetDirection == Vector3.zero) {
-                        targetDirection = transform.forward;
+        public void HandleRotation(float delta) {
+            if (animatorHandler.canRotate) {
+                if (inputHandler.lockOnFlag) {
+                    // 록온을 해도 달리거나 구를때는, 이동하던 방향으로 행동
+                    if (inputHandler.sprintFlag || inputHandler.rollFlag) {
+                        Vector3 targetDirection = Vector3.zero;
+                        targetDirection = cameraHandler.cameraTransform.forward * inputHandler.vertical;
+                        targetDirection += cameraHandler.cameraTransform.right * inputHandler.horizontal;
+                        targetDirection.Normalize();
+                        targetDirection.y = 0;
+                        if (targetDirection == Vector3.zero) {
+                            targetDirection = transform.forward;
+                        }
+                        Quaternion tr = Quaternion.LookRotation(targetDirection);
+                        Quaternion targetRotation = Quaternion.Slerp(transform.rotation, tr, rotationSpeed * Time.deltaTime);
+                        transform.rotation = targetRotation;
+                    } else {
+                        Vector3 rotationDirection = moveDirection;
+                        rotationDirection = cameraHandler.currentLockOnTarget.position - transform.position;
+                        rotationDirection.y = 0;
+                        rotationDirection.Normalize();
+                        Quaternion tr = Quaternion.LookRotation(rotationDirection);
+                        Quaternion targetRotation = Quaternion.Slerp(transform.rotation, tr, rotationSpeed * Time.deltaTime);
+                        transform.rotation = targetRotation;
                     }
-                    Quaternion tr = Quaternion.LookRotation(targetDirection);
-                    Quaternion targetRotation = Quaternion.Slerp(transform.rotation, tr, rotationSpeed * Time.deltaTime);
-                    transform.rotation = targetRotation;
                 } else {
-                    Vector3 rotationDirection = moveDirection;
-                    rotationDirection = cameraHandler.currentLockOnTarget.position - transform.position;
-                    rotationDirection.y = 0;
-                    rotationDirection.Normalize();
-                    Quaternion tr = Quaternion.LookRotation(rotationDirection);
-                    Quaternion targetRotation = Quaternion.Slerp(transform.rotation, tr, rotationSpeed * Time.deltaTime);
-                    transform.rotation = targetRotation;
+                    // 바라볼 방향
+                    Vector3 targetDir = Vector3.zero;
+                    // WASD 방향키 값을 반영한다.
+                    targetDir = cameraObject.forward * inputHandler.vertical;
+                    targetDir += cameraObject.right * inputHandler.horizontal;
+                    targetDir.Normalize();
+                    // 위아래로는 회전하지 않을 것
+                    targetDir.y = 0;
+
+                    // 방향 조작이 없다면 캐릭터의 현재좌표에서 정면을 바라봄
+                    if (targetDir == Vector3.zero)
+                        targetDir = myTransform.forward;
+
+                    float moveOverride = inputHandler.moveAmount;
+
+                    // 스크립트에서 회전 처리를 다루는 경우 Quaternion 클래스와 이 클래스의 함수를 사용하여 회전 값을 만들고 수정해야 한다.
+                    // 일부의 경우 스크립트에서 오일러 각을 사용하는 것이 더 좋다. 이 경우 각을 변수로 유지하고 회전에 오일러 각으로 적용하는 데만 사용해야 하고 궁극적으로 Quaterion 으로 저장되어야 한다.
+                    float rs = rotationSpeed;
+                    Quaternion tr = Quaternion.LookRotation(targetDir); // 회전
+                    Quaternion targetRotation = Quaternion.Slerp(myTransform.rotation, tr, rs * delta); // 회전이 부드럽게 이어지도록한다
+                    myTransform.rotation = targetRotation; // 회전값을 Quaternion으로 저장한다.
                 }
-            } else {
-                // 바라볼 방향
-                Vector3 targetDir = Vector3.zero;
-                // WASD 방향키 값을 반영한다.
-                targetDir = cameraObject.forward * inputHandler.vertical;
-                targetDir += cameraObject.right * inputHandler.horizontal;
-                targetDir.Normalize();
-                // 위아래로는 회전하지 않을 것
-                targetDir.y = 0;
-
-                // 방향 조작이 없다면 캐릭터의 현재좌표에서 정면을 바라봄
-                if (targetDir == Vector3.zero)
-                    targetDir = myTransform.forward;
-
-                float moveOverride = inputHandler.moveAmount;
-
-                // 스크립트에서 회전 처리를 다루는 경우 Quaternion 클래스와 이 클래스의 함수를 사용하여 회전 값을 만들고 수정해야 한다.
-                // 일부의 경우 스크립트에서 오일러 각을 사용하는 것이 더 좋다. 이 경우 각을 변수로 유지하고 회전에 오일러 각으로 적용하는 데만 사용해야 하고 궁극적으로 Quaterion 으로 저장되어야 한다.
-                float rs = rotationSpeed;
-                Quaternion tr = Quaternion.LookRotation(targetDir); // 회전
-                Quaternion targetRotation = Quaternion.Slerp(myTransform.rotation, tr, rs * delta); // 회전이 부드럽게 이어지도록한다
-                myTransform.rotation = targetRotation; // 회전값을 Quaternion으로 저장한다.
             }
         }
 
@@ -162,8 +164,7 @@ namespace sg {
                 animatorHandler.UpdateAnimatorValues(inputHandler.moveAmount, 0, playerManager.isSprinting);
             }
 
-            if (animatorHandler.canRotate)
-                HandleRotation(delta);
+                
         }
 
         // 질주,회피


### PR DESCRIPTION
# Animator
- 플레이어가 자체적으로 회전이 가능하고 가능하지 않은 상황을 제어할 수 있도록 bool 매개변수 canRotate 추가

# AnimatorManager
- 애니메이션 재생동안 회전 불가

# PlayerAnimatorManager
- 애니메이션 이벤트로 회전이 가능해지는 순간과 다시 불가능해지는 순간을 정할 수 있도록 함수 생성
- 이벤트로 Animator의 canRotate를 제어

# PlayerManager
- bool 변수 canRotate
- animator의 매개변수 canRotate에 따라 제어
- 플레이어의 회전함수 호출

# PlayerLocomotion
- 기존 플레이어의 회전을 HandleMovement에서 호출했기 때문에 isInteracting이 true라면 회전이 불가능했음
- 공격도중 아주 적은 시간간격이지만 방향 전환이 가능한 DS 시리즈 처럼 만들기 위해 회전하는 부분을 PlayerManager에서 처리하도록 한다.