### PR TITLE
Fix

### DIFF
--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -21,18 +21,17 @@ namespace sg {
         public bool isUsingRightHand, isUsingLeftHand;
         public bool isInvulnerable;
 
+        PlayerAnimatorManager playerAnimatorManager;
         PlayerStats playerStats;
         PlayerLocomotion playerLocomotion;
         CameraHandler cameraHandler;
         InteractableUI interactableUI; // 상호작용때 나타나는 메세지 창
 
         private void Awake() {
+            playerAnimatorManager = GetComponentInChildren<PlayerAnimatorManager>();
             cameraHandler = FindObjectOfType<CameraHandler>();
             playerStats = GetComponent<PlayerStats>();
             backStabCollider = GetComponentInChildren<BackStabCollider>();
-        }
-
-        void Start() {
             inputHandler = GetComponent<InputHandler>();
             anim = GetComponentInChildren<Animator>();
             playerLocomotion = GetComponent<PlayerLocomotion>();
@@ -53,8 +52,9 @@ namespace sg {
             playerLocomotion.HandleRollingAndSprinting(delta);
             playerLocomotion.HandleJumping();
             playerStats.RegenerateStamina();
-
             CheckForInteractableObject();
+
+            playerAnimatorManager.canRotate = anim.GetBool("canRotate");
 
             // 이동키와 백스텝키가 짧은 간격으로 눌리면 백스텝 이후 sprint 애니메이션이 실행되는 경우가 있다.
             // 이를 해결하기 위해 delay 추가
@@ -71,6 +71,7 @@ namespace sg {
             // Rigidbody를 통해 처리되는 움직임은 FixedUpdate에서 처리되는것이 좋음
             playerLocomotion.HandleMovement(delta);
             playerLocomotion.HandleFalling(delta, playerLocomotion.moveDirection);
+            playerLocomotion.HandleRotation(delta);
         }
 
         private void LateUpdate() {


### PR DESCRIPTION
# Animator
- 플레이어가 자체적으로 회전이 가능하고 가능하지 않은 상황을 제어할 수 있도록 bool 매개변수 canRotate 추가

# AnimatorManager
- 애니메이션 재생동안 회전 불가

# PlayerAnimatorManager
- 애니메이션 이벤트로 회전이 가능해지는 순간과 다시 불가능해지는 순간을 정할 수 있도록 함수 생성
- 이벤트로 Animator의 canRotate를 제어

# PlayerManager
- bool 변수 canRotate
- animator의 매개변수 canRotate에 따라 제어
- 플레이어의 회전함수 호출

# PlayerLocomotion
- 기존 플레이어의 회전을 HandleMovement에서 호출했기 때문에 isInteracting이 true라면 회전이 불가능했음
- 공격도중 아주 적은 시간간격이지만 방향 전환이 가능한 DS 시리즈 처럼 만들기 위해 회전하는 부분을 PlayerManager에서 처리하도록 한다.