### PR TITLE
Riposte

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -588,6 +588,28 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-4304708652415388249
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4561258091624907548}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9347826
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-4262117187818169086
 AnimatorState:
   serializedVersion: 6
@@ -706,6 +728,28 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-3149884016130907771
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4561258091624907548}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.90625
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-2835223261342340991
 AnimatorState:
   serializedVersion: 6
@@ -733,6 +777,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-2740930136752431051
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3113570552372975617}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9423077
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-2587876034128584378
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -799,6 +868,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &-1607487726440668554
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Parry_GetUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 6153562569850114856}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 86035818097fe034798f98ab9f483f20, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &-1391090153713725658
 AnimatorState:
   serializedVersion: 6
@@ -875,6 +971,33 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: b2a6624b85d71c54a9d246252061b849, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-1117597461007863893
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Parry
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8586642148827452220}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 795f7bd02ea2c0f48807c0ceaf84ae28, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -1252,6 +1375,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetBool: canRotate
   status: 1
+--- !u!1102 &221038576124829532
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Parried
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3149884016130907771}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 8768d67816911b540bc08e32c1cd4f88, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &805918016173055142
 AnimatorState:
   serializedVersion: 6
@@ -1465,6 +1615,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetBool: isUsingRightHand
   status: 0
+--- !u!1102 &1712414704290404051
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Riposte
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -4304708652415388249}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: c0283ef56d905754db2adb35e5bb8a73, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &1937375425316634833
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1535,6 +1712,32 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 30, y: 80, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 6800534231876430101}
+--- !u!1102 &3113570552372975617
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Parry_Death
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 1145946649e0de74eb8dacb62e7f89a1, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &3208383363395790153
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1964,19 +2167,37 @@ AnimatorStateMachine:
     m_Position: {x: 580, y: -420, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4552435795597197025}
-    m_Position: {x: 100, y: 100, z: 0}
+    m_Position: {x: 340, y: 240, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6047846892116732301}
-    m_Position: {x: 100, y: 150, z: 0}
+    m_Position: {x: 340, y: 290, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8787761360574702309}
-    m_Position: {x: -120, y: 220, z: 0}
+    m_Position: {x: 120, y: 360, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5493193844379995381}
-    m_Position: {x: 280, y: 220, z: 0}
+    m_Position: {x: 520, y: 360, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1154965276067657945}
     m_Position: {x: 100, y: -410, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1607487726440668554}
+    m_Position: {x: 190, y: -660, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 221038576124829532}
+    m_Position: {x: 100, y: 140, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1117597461007863893}
+    m_Position: {x: 100, y: 90, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1712414704290404051}
+    m_Position: {x: 400, y: -530, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 6073903915226489255}
+    m_Position: {x: 400, y: -580, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3113570552372975617}
+    m_Position: {x: 610, y: -660, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -1987,6 +2208,56 @@ AnimatorStateMachine:
   m_ExitPosition: {x: -130, y: -120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 4561258091624907548}
+--- !u!1102 &6073903915226489255
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Riposted
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 6949823787448273587}
+  - {fileID: -2740930136752431051}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f905fa7cf0421ef46ab0b44d19b4493f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &6153562569850114856
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4561258091624907548}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &6800534231876430101
 AnimatorState:
   serializedVersion: 6
@@ -2013,6 +2284,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &6949823787448273587
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1607487726440668554}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9423077
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!114 &7849893155914889298
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2142,6 +2438,28 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.7916667
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &8586642148827452220
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4561258091624907548}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/Assets/Data/Prefabs/Enemy.prefab
+++ b/Assets/Data/Prefabs/Enemy.prefab
@@ -30,6 +30,7 @@ Transform:
   m_Children:
   - {fileID: 1840872851}
   - {fileID: 371654648}
+  - {fileID: 4436255637133151642}
   m_Father: {fileID: 1247414621750747085}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -141,7 +142,7 @@ GameObject:
   - component: {fileID: 371654648}
   - component: {fileID: 371654650}
   - component: {fileID: 371654651}
-  - component: {fileID: 371654652}
+  - component: {fileID: 4436255635506644370}
   m_Layer: 12
   m_Name: BackStab Collider
   m_TagString: Untagged
@@ -193,7 +194,7 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.43480468, y: 0.73867637, z: 0.0037221909}
   m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.084769726}
---- !u!114 &371654652
+--- !u!114 &4436255635506644370
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -202,10 +203,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 371654647}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 470f95bf7dfa9bb498a9ebd6a3b87073, type: 3}
+  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  backStabberStandPoint: {fileID: 1288313293}
+  criticalDamagerStandPosition: {fileID: 1288313293}
 --- !u!1 &634820068
 GameObject:
   m_ObjectHideFlags: 0
@@ -332,6 +333,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1288313293}
+  - {fileID: 4436255636361755777}
   m_Father: {fileID: 1247414621750747085}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -472,7 +474,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1288313292}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.75}
+  m_LocalPosition: {x: -0.05, y: 0, z: -0.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -596,6 +598,325 @@ NavMeshAgent:
   m_BaseOffset: 0
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
+--- !u!1 &19379091284972672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5725917375320580103}
+  m_Layer: 9
+  m_Name: Head_Attachment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5725917375320580103
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 19379091284972672}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.4071082e-15, y: 0.21543543, z: 0.010532023}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6472099338095951124}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &79898019359676919
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1215328535008142785}
+  m_Layer: 9
+  m_Name: Thumb_03_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1215328535008142785
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 79898019359676919}
+  m_LocalRotation: {x: -0.06197722, y: -0.17259754, z: -0.23208837, w: 0.9552507}
+  m_LocalPosition: {x: -0.056655705, y: 0.0000000146683306, z: 0.000000007916242}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 167885150368866334}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &155856990145368187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6500307785462023080}
+  m_Layer: 9
+  m_Name: Clavicle_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6500307785462023080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155856990145368187}
+  m_LocalRotation: {x: 0.6243446, y: 0.50307226, z: 0.41116875, w: -0.43365029}
+  m_LocalPosition: {x: -0.05801529, y: -0.04191418, z: 0.0744715}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3899419159179878535}
+  m_Father: {fileID: 5338167718811397838}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &288193583463579511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8496984858403547758}
+  m_Layer: 9
+  m_Name: UpperLeg_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8496984858403547758
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 288193583463579511}
+  m_LocalRotation: {x: -0.72358024, y: -0.05821991, z: -0.024835788, w: 0.6873321}
+  m_LocalPosition: {x: 0.0411578, y: -0.026920758, z: 0.098967105}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3227778546943542901}
+  m_Father: {fileID: 9081966979823668343}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &307668898221485925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4052649600722018405}
+  m_Layer: 9
+  m_Name: Tome_Attachment_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4052649600722018405
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 307668898221485925}
+  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
+  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &507769061206011779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5338167718811397838}
+  m_Layer: 9
+  m_Name: Spine_03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5338167718811397838
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 507769061206011779}
+  m_LocalRotation: {x: 0.9918718, y: -0.121152095, z: 0.016842717, w: -0.03505519}
+  m_LocalPosition: {x: -0.17903721, y: -0.000000014901161, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 792284055194252288}
+  - {fileID: 6500307785462023080}
+  - {fileID: 596899668138413448}
+  m_Father: {fileID: 1152179737579750028}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &526384034016461475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 167885150368866334}
+  m_Layer: 9
+  m_Name: Thumb_02_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &167885150368866334
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526384034016461475}
+  m_LocalRotation: {x: -0.0644364, y: -0.20452474, z: 0.01937257, w: 0.9765461}
+  m_LocalPosition: {x: -0.06370216, y: -0.00000005029142, z: -0.000000009313226}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1215328535008142785}
+  m_Father: {fileID: 922387819355016208}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1004133773639119874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4922087436607844220}
+  m_Layer: 9
+  m_Name: Finger_01_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4922087436607844220
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1004133773639119874}
+  m_LocalRotation: {x: -0.033403162, y: 0.13207105, z: -0.16915055, w: -0.97612995}
+  m_LocalPosition: {x: 0.099825, y: 0.0011600349, z: 0.032833427}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5244018147658018127}
+  m_Father: {fileID: 1124239235835893587}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1021069946179628750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3725265733891815479}
+  m_Layer: 9
+  m_Name: Spine_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3725265733891815479
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1021069946179628750}
+  m_LocalRotation: {x: 0.99508506, y: -0.098823294, z: 0.0062347334, w: -0.0009606643}
+  m_LocalPosition: {x: -0.10393268, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1152179737579750028}
+  m_Father: {fileID: 9081966979823668343}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1047716934116235217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3899419159179878535}
+  m_Layer: 9
+  m_Name: Shoulder_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3899419159179878535
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1047716934116235217}
+  m_LocalRotation: {x: 0.27298498, y: 0.16956079, z: 0.46912387, w: 0.82258815}
+  m_LocalPosition: {x: 0.1319786, y: 0.0000065022614, z: 0.000000037252903}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1590882301947647278}
+  m_Father: {fileID: 6500307785462023080}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1247414621750747090
 GameObject:
   m_ObjectHideFlags: 0
@@ -625,8 +946,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1247414621750747090}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 2.21}
+  m_LocalRotation: {x: 0, y: 0, z: -0, w: -1}
+  m_LocalPosition: {x: -3.5, y: 0, z: -1.56}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -638,7 +959,7 @@ Transform:
   - {fileID: 764030083}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 360, z: 0}
 --- !u!114 &1247414621750747086
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -706,8 +1027,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   lockOnTransform: {fileID: 1284610322}
-  backStabBoxCollider: {fileID: 371654651}
-  backStabCollider: {fileID: 0}
+  backStabCollider: {fileID: 4436255635506644370}
+  riposteCollider: {fileID: 4436255637133151643}
+  canBeRiposted: 1
   pendingCriticalDamage: 0
   isPerformingAction: 0
   isInteracting: 0
@@ -762,1402 +1084,250 @@ MonoBehaviour:
     m_Bits: 512
   characterCollider: {fileID: 1247414621750747087}
   characterColliderBlocker: {fileID: 1840872852}
---- !u!1001 &1247414621529216314
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1247414621750747085}
-    m_Modifications:
-    - target: {fileID: -9211815070973405100, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -9207643095094715964, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.056655705
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.0000000146683306
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000007916242
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9552507
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.06197722
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.17259754
-      objectReference: {fileID: 0}
-    - target: {fileID: -9110216758858419973, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.23208837
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.0014476385
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0014362596
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.96720195
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.109417275
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.22795282
-      objectReference: {fileID: 0}
-    - target: {fileID: -8692994035542196204, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.024202544
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8499302264141489256, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.03513327
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.00000014156103
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0000000144355
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9141038
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.005326134
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.030390467
-      objectReference: {fileID: 0}
-    - target: {fileID: -8325972794387765038, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.40430483
-      objectReference: {fileID: 0}
-    - target: {fileID: -8150708277685482813, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.06370216
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.00000005029142
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.000000009313226
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9765461
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.0644364
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.20452474
-      objectReference: {fileID: 0}
-    - target: {fileID: -7846459833142463196, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.01937257
-      objectReference: {fileID: 0}
-    - target: {fileID: -7825563014278363839, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000000040818122
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000000069849193
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.80697495
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.30367216
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.20954996
-      objectReference: {fileID: 0}
-    - target: {fileID: -7760450749380214294, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.46115452
-      objectReference: {fileID: 0}
-    - target: {fileID: -7637643721665833063, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -7618892409413387591, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.111889705
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99912876
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.000000003705289
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.0000000013216378
-      objectReference: {fileID: 0}
-    - target: {fileID: -7419915781069023054, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.041733377
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.035140503
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.011706891
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.04505539
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.934517
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.10272303
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.13435821
-      objectReference: {fileID: 0}
-    - target: {fileID: -7096742651580573398, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.3131672
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.18151172
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000029802322
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000013969839
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.01716675
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.9948446
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.09800402
-      objectReference: {fileID: 0}
-    - target: {fileID: -7011284792763705418, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.019615274
-      objectReference: {fileID: 0}
-    - target: {fileID: -6933984331131501845, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.10393268
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.0009606643
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.99508506
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.098823294
-      objectReference: {fileID: 0}
-    - target: {fileID: -6702067012661744371, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.0062347334
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.0000065022614
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000037252903
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.82258815
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.27298498
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.16956079
-      objectReference: {fileID: 0}
-    - target: {fileID: -6389990024915159619, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.46912387
-      objectReference: {fileID: 0}
-    - target: {fileID: -6184164969240582618, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -6000111523363111622, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.037911892
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000000376167
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000000028667273
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.98633116
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.04422331
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.022021903
-      objectReference: {fileID: 0}
-    - target: {fileID: -5875542077836118784, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.15719514
-      objectReference: {fileID: 0}
-    - target: {fileID: -5777015999960571861, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.026920708
-      objectReference: {fileID: 0}
-    - target: {fileID: -5777015999960571861, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.020682381
-      objectReference: {fileID: 0}
-    - target: {fileID: -5777015999960571861, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.056999438
-      objectReference: {fileID: 0}
-    - target: {fileID: -5777015999960571861, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7304186
-      objectReference: {fileID: 0}
-    - target: {fileID: -5777015999960571861, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.6803029
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.1039656
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.003987163
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.99706274
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.001012347
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.07592192
-      objectReference: {fileID: 0}
-    - target: {fileID: -5642154710079545879, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.010044581
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.37712362
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000008940697
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000000055879354
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.15420388
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.8367191
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.51112205
-      objectReference: {fileID: 0}
-    - target: {fileID: -4878788319745106522, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.121969916
-      objectReference: {fileID: 0}
-    - target: {fileID: -4609973567363353024, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.12164436
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000014901161
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000013038516
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.54279387
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.42928478
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.52979195
-      objectReference: {fileID: 0}
-    - target: {fileID: -3990698397054048210, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49031618
-      objectReference: {fileID: 0}
-    - target: {fileID: -3784695491857803630, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.05801529
-      objectReference: {fileID: 0}
-    - target: {fileID: -3784695491857803630, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.43365029
-      objectReference: {fileID: 0}
-    - target: {fileID: -3784695491857803630, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.6243446
-      objectReference: {fileID: 0}
-    - target: {fileID: -3784695491857803630, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.50307226
-      objectReference: {fileID: 0}
-    - target: {fileID: -3784695491857803630, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.41116875
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.04248817
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000023621396
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0000000010913936
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9300714
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.022871796
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.016431663
-      objectReference: {fileID: 0}
-    - target: {fileID: -3729650930284352584, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.36629796
-      objectReference: {fileID: 0}
-    - target: {fileID: -3550759674550072776, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -3437183457538845872, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -3279003018169450748, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 611b9d6b7da80f5419ff2ea86ed603af, type: 2}
-    - target: {fileID: -3091424283633995617, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -3084546381883209956, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.11284034
-      objectReference: {fileID: 0}
-    - target: {fileID: -3084546381883209956, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000018626451
-      objectReference: {fileID: 0}
-    - target: {fileID: -3084546381883209956, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.000000007450581
-      objectReference: {fileID: 0}
-    - target: {fileID: -3084546381883209956, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.000000008877997
-      objectReference: {fileID: 0}
-    - target: {fileID: -3084546381883209956, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.000000005690149
-      objectReference: {fileID: 0}
-    - target: {fileID: -3042181013470404261, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -3016557516338679992, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2966385152125808556, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2922925646491181763, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2785774523018559695, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2468419626989822776, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2430163615715248214, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2406627654518480413, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.03513328
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000000037740392
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0000000010732037
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.91213846
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.0054590213
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.030513607
-      objectReference: {fileID: 0}
-    - target: {fileID: -2219848893153055739, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.4087086
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000003280118
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.00000005029142
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.98697174
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.044269163
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.022257227
-      objectReference: {fileID: 0}
-    - target: {fileID: -2057211150038816365, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.15307403
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.0411578
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.026920758
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.6873321
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.72358024
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.05821991
-      objectReference: {fileID: 0}
-    - target: {fileID: -1971188741579686060, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.024835788
-      objectReference: {fileID: 0}
-    - target: {fileID: -1662341123100217685, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000007264316
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.00000021979213
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9361888
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.042597283
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.25559175
-      objectReference: {fileID: 0}
-    - target: {fileID: -1565749857817616358, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.23750533
-      objectReference: {fileID: 0}
-    - target: {fileID: -1534848557306558213, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -1407328588852412372, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -1320221589979902067, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.33947405
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0014491217
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0014362646
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9746633
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.09152292
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.2011993
-      objectReference: {fileID: 0}
-    - target: {fileID: -552756469904255736, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.034261495
-      objectReference: {fileID: 0}
-    - target: {fileID: -478896753309311375, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: -87901948772251155, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.07295759
-      objectReference: {fileID: 0}
-    - target: {fileID: -87901948772251155, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -1.4832047e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: -87901948772251155, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -87901948772251155, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 3.8191672e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: -87901948772251155, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 3.3750773e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: 207472850613022373, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 224536251795055821, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.39930907
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000000059604645
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.2738255e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7154775
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.69640523
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.046938326
-      objectReference: {fileID: 0}
-    - target: {fileID: 411026301916818062, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.030142298
-      objectReference: {fileID: 0}
-    - target: {fileID: 680184063773988667, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 794686288788342669, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -7.3880635e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 794686288788342669, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 794686288788342669, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.00000026481644
-      objectReference: {fileID: 0}
-    - target: {fileID: 794686288788342669, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.00000026481635
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Name
-      value: EnemyModel
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1176686548608896205, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1228196078407172538, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1346693338035923533, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1516230686343559775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1995506796041576762, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.40876657
-      objectReference: {fileID: 0}
-    - target: {fileID: 1995506796041576762, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.5020848
-      objectReference: {fileID: 0}
-    - target: {fileID: 1995506796041576762, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.6266735
-      objectReference: {fileID: 0}
-    - target: {fileID: 1995506796041576762, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.4337061
-      objectReference: {fileID: 0}
-    - target: {fileID: 2062880239462900024, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.27114487
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.00000003259629
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.00038135424
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9846755
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.15530588
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.07220194
-      objectReference: {fileID: 0}
-    - target: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.03288075
-      objectReference: {fileID: 0}
-    - target: {fileID: 2261973912390581236, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.3771233
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000014901161
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.0000008530915
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.1254083
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.87222844
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.47165158
-      objectReference: {fileID: 0}
-    - target: {fileID: 2391349814839302166, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.032174
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000000037285645
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -3.0195224e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9487123
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.042240687
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.0028564357
-      objectReference: {fileID: 0}
-    - target: {fileID: 2426586235841241251, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.31329337
-      objectReference: {fileID: 0}
-    - target: {fileID: 2451608504771551539, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2693625344640494459, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2701067078280255519, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.06370147
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000007788651
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.0000004246831
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.98507446
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.06596402
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.15778397
-      objectReference: {fileID: 0}
-    - target: {fileID: 2894879039564077524, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.019527182
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980238977816895026, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.040935885
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000092282426
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.000000056810677
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.95006424
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.042210087
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.0030954692
-      objectReference: {fileID: 0}
-    - target: {fileID: 2999473921630935526, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.30917105
-      objectReference: {fileID: 0}
-    - target: {fileID: 3081174387179216082, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3101355258955623606, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3414138005845122111, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3440550138123258640, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3466224332873318725, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3668086056121675338, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.2711453
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000011197699
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.00038136943
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.98065853
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.1824338
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.019140687
-      objectReference: {fileID: 0}
-    - target: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.06826788
-      objectReference: {fileID: 0}
-    - target: {fileID: 3919000222598212590, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4394627511276918094, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.39930925
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.00000035762787
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.2739676e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7634613
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.6410804
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.065192334
-      objectReference: {fileID: 0}
-    - target: {fileID: 4432926875002786639, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.04350663
-      objectReference: {fileID: 0}
-    - target: {fileID: 4562083118368882700, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.1128404
-      objectReference: {fileID: 0}
-    - target: {fileID: 4562083118368882700, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.000000007450581
-      objectReference: {fileID: 0}
-    - target: {fileID: 4562083118368882700, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4562083118368882700, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4562083118368882700, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.10396602
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0039899843
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.026726522
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9914906
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.013495237
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.12788932
-      objectReference: {fileID: 0}
-    - target: {fileID: 4929162571111373775, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.020216519
-      objectReference: {fileID: 0}
-    - target: {fileID: 5332809968238436118, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 5866666021909216657, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: e3bffc4c9d7ae7946bbef483ae5b3d32, type: 2}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.0011600349
-      objectReference: {fileID: 0}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.032833427
-      objectReference: {fileID: 0}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.97612995
-      objectReference: {fileID: 0}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.033403162
-      objectReference: {fileID: 0}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.13207105
-      objectReference: {fileID: 0}
-    - target: {fileID: 6125300718146222662, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.16915055
-      objectReference: {fileID: 0}
-    - target: {fileID: 6315765792793278136, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6392886965815168175, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.042488072
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000028777868
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.000000016763806
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9318164
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.022789175
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.016550567
-      objectReference: {fileID: 0}
-    - target: {fileID: 6451910341524404341, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.3618357
-      objectReference: {fileID: 0}
-    - target: {fileID: 6472589064474706198, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.17903721
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.000000014901161
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.03505519
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.9918718
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.121152095
-      objectReference: {fileID: 0}
-    - target: {fileID: 6582942952909536244, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.016842717
-      objectReference: {fileID: 0}
-    - target: {fileID: 6598595493709832198, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6610929801062596353, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6820295876304958116, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.035139985
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.011709997
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.045055427
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.9107151
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.11694848
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.1735315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7038999580958108073, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.35610104
-      objectReference: {fileID: 0}
-    - target: {fileID: 7620755400191891017, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.0014336109
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.9057569
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.025198698
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5383493
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.4644048
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.533213
-      objectReference: {fileID: 0}
-    - target: {fileID: 8018118334481897805, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.45846716
-      objectReference: {fileID: 0}
-    - target: {fileID: 8101567051441690793, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8185785237177856587, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.09982523
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0011595332
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.9861849
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.0033722788
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.028836798
-      objectReference: {fileID: 0}
-    - target: {fileID: 8298002316568741239, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.16308427
-      objectReference: {fileID: 0}
-    - target: {fileID: 8618280739144093859, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8927594604549699016, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
---- !u!4 &1124239235835893587 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2221872609835778665, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1640732483817173713 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2129882858598017131 stripped
+--- !u!1 &1253894068147768686
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 361101427359601872}
+  m_Layer: 9
+  m_Name: Shoulder_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &361101427359601872
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1253894068147768686}
+  m_LocalRotation: {x: 0.30367216, y: 0.20954996, z: 0.46115452, w: 0.80697495}
+  m_LocalPosition: {x: -0.13197872, y: 0.000000040818122, z: -0.0000000069849193}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7573790231232397362}
+  m_Father: {fileID: 792284055194252288}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1258850235521535230
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8036675019150793943}
+  m_Layer: 9
+  m_Name: Toes_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8036675019150793943
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1258850235521535230}
+  m_LocalRotation: {x: 3.8191672e-14, y: -0.7071068, z: 3.3750773e-14, w: 0.7071068}
+  m_LocalPosition: {x: -0.07295759, y: -1.4832047e-10, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3314775296628987190}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1320120343323587063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 348205520244569659}
+  m_Layer: 9
+  m_Name: Shield_Attachment_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &348205520244569659
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320120343323587063}
+  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
+  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1418250738835078047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6091700693805221158}
+  m_Layer: 9
+  m_Name: Finger_04_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6091700693805221158
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418250738835078047}
+  m_LocalRotation: {x: 0.01664637, y: 0.096525334, z: -0.16913006, w: 0.98071444}
+  m_LocalPosition: {x: -0.030032393, y: 1.1368684e-15, z: 7.105427e-17}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8105977730227632447}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1747338589152330241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 858910326470573725}
+  m_Layer: 9
+  m_Name: IndexFinger_04_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &858910326470573725
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1747338589152330241}
+  m_LocalRotation: {x: -0.004519649, y: -0.028039929, z: -0.15906802, w: 0.986859}
+  m_LocalPosition: {x: -0.03779794, y: -1.4210854e-15, z: 7.105427e-17}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4556047848278794298}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1964657275453623970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2189733746538761995}
+  m_Layer: 9
+  m_Name: Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2189733746538761995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964657275453623970}
+  m_LocalRotation: {x: -0.46203893, y: 0.53527564, z: 0.46203893, w: 0.53527564}
+  m_LocalPosition: {x: 0.006935013, y: 0.035117745, z: 3.2494063e-16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1152179737579750028}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2129882858598017131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1640732483817173713}
+  - component: {fileID: 4622137240449984683}
+  - component: {fileID: 561958107}
+  - component: {fileID: 561958110}
+  m_Layer: 9
+  m_Name: EnemyModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1640732483817173713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129882858598017131}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1663095878503063804}
+  - {fileID: 8085173571690234859}
+  m_Father: {fileID: 1247414621750747085}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &4622137240449984683
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2129882858598017131}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
+  m_Controller: {fileID: 9100000, guid: e3bffc4c9d7ae7946bbef483ae5b3d32, type: 2}
+  m_CullingMode: 1
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 1
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!114 &561958107
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2190,11 +1360,207 @@ MonoBehaviour:
   leftHandSlot: {fileID: 317928797}
   leftHandDamageCollider: {fileID: 0}
   rightHandDamageCollider: {fileID: 0}
---- !u!1 &2569334547004177264 stripped
+--- !u!1 &2282598217840861177
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 3668086056121675338, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3522733748536472985}
+  m_Layer: 9
+  m_Name: IndexFinger_02_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3522733748536472985
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2282598217840861177}
+  m_LocalRotation: {x: -0.042240687, y: -0.0028564357, z: 0.31329337, w: 0.9487123}
+  m_LocalPosition: {x: -0.040936317, y: 0.000000037285645, z: -3.0195224e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4556047848278794298}
+  m_Father: {fileID: 2376984514544650451}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2401883525668820095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1663095878503063804}
+  - component: {fileID: 4841669618046331454}
+  m_Layer: 9
+  m_Name: Md_Char_Low_Poly_Man
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1663095878503063804
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2401883525668820095}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1640732483817173713}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4841669618046331454
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2401883525668820095}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 611b9d6b7da80f5419ff2ea86ed603af, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 6856591950794880597, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
+  m_Bones:
+  - {fileID: 9081966979823668343}
+  - {fileID: 3725265733891815479}
+  - {fileID: 4511584776602957073}
+  - {fileID: 8496984858403547758}
+  - {fileID: 1152179737579750028}
+  - {fileID: 1512073418717577140}
+  - {fileID: 3227778546943542901}
+  - {fileID: 5338167718811397838}
+  - {fileID: 3243923388340897948}
+  - {fileID: 3485912562616356140}
+  - {fileID: 596899668138413448}
+  - {fileID: 792284055194252288}
+  - {fileID: 6500307785462023080}
+  - {fileID: 3314775296628987190}
+  - {fileID: 4935603886607176230}
+  - {fileID: 6472099338095951124}
+  - {fileID: 361101427359601872}
+  - {fileID: 3899419159179878535}
+  - {fileID: 8036675019150793943}
+  - {fileID: 1894042941358002871}
+  - {fileID: 7573790231232397362}
+  - {fileID: 1590882301947647278}
+  - {fileID: 2681769484870082267}
+  - {fileID: 1124239235835893587}
+  - {fileID: 922387819355016208}
+  - {fileID: 2376984514544650451}
+  - {fileID: 7090875665751363661}
+  - {fileID: 8133562697900965011}
+  - {fileID: 6136246589827452661}
+  - {fileID: 4922087436607844220}
+  - {fileID: 167885150368866334}
+  - {fileID: 3522733748536472985}
+  - {fileID: 6733491399004700290}
+  - {fileID: 4135177312034376942}
+  - {fileID: 4102763175617531100}
+  - {fileID: 5244018147658018127}
+  - {fileID: 1215328535008142785}
+  - {fileID: 4556047848278794298}
+  - {fileID: 8105977730227632447}
+  - {fileID: 8866147520645510432}
+  - {fileID: 8231706724182408361}
+  - {fileID: 2106425848123096552}
+  - {fileID: 858910326470573725}
+  - {fileID: 6091700693805221158}
+  - {fileID: 1614913700655172968}
+  - {fileID: 3278199954002114090}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 9081966979823668343}
+  m_AABB:
+    m_Center: {x: 0.02152279, y: -0.009413511, z: 0}
+    m_Extent: {x: 0.9414129, y: 0.2786869, z: 1.0245608}
+  m_DirtyAABB: 0
+--- !u!1 &2569334547004177264
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2681769484870082267}
+  - component: {fileID: 317928797}
+  m_Layer: 9
+  m_Name: Hand_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2681769484870082267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2569334547004177264}
+  m_LocalRotation: {x: -0.1824338, y: -0.019140687, z: -0.06826788, w: 0.98065853}
+  m_LocalPosition: {x: -0.2711453, y: -0.000000011197699, z: -0.00038136943}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7090875665751363661}
+  - {fileID: 2376984514544650451}
+  - {fileID: 232910987196197086}
+  - {fileID: 348205520244569659}
+  - {fileID: 922387819355016208}
+  - {fileID: 4052649600722018405}
+  m_Father: {fileID: 7573790231232397362}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &317928797
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2213,16 +1579,819 @@ MonoBehaviour:
   isBackSlot: 0
   currentWeapon: {fileID: 0}
   currentWeaponModel: {fileID: 0}
---- !u!4 &2681769484870082267 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3780837713738550241, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5329917998478383509 stripped
+--- !u!1 &2822808145628511956
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 6392886965815168175, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_PrefabInstance: {fileID: 1247414621529216314}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4556047848278794298}
+  m_Layer: 9
+  m_Name: IndexFinger_03_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4556047848278794298
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2822808145628511956}
+  m_LocalRotation: {x: -0.04422331, y: -0.022021903, z: 0.15719514, w: 0.98633116}
+  m_LocalPosition: {x: -0.037911892, y: 0.00000000376167, z: -0.0000000028667273}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 858910326470573725}
+  m_Father: {fileID: 3522733748536472985}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3293097305115279476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 596899668138413448}
+  m_Layer: 9
+  m_Name: Neck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &596899668138413448
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3293097305115279476}
+  m_LocalRotation: {x: 0.000000003705289, y: 0.0000000013216378, z: 0.041733377, w: 0.99912876}
+  m_LocalPosition: {x: -0.111889705, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6472099338095951124}
+  m_Father: {fileID: 5338167718811397838}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3695880858328937481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3485912562616356140}
+  m_Layer: 9
+  m_Name: Ankle_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3485912562616356140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3695880858328937481}
+  m_LocalRotation: {x: 0.87222844, y: 0.47165158, z: 0.032174, w: -0.1254083}
+  m_LocalPosition: {x: 0.3771233, y: 0.00000014901161, z: -0.0000008530915}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4935603886607176230}
+  m_Father: {fileID: 3227778546943542901}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3759970260961836609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4935603886607176230}
+  m_Layer: 9
+  m_Name: Ball_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4935603886607176230
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3759970260961836609}
+  m_LocalRotation: {x: 0.000000008877997, y: 0.000000005690149, z: -0.2700158, w: 0.96285594}
+  m_LocalPosition: {x: 0.11284034, y: -0.000000018626451, z: -0.000000007450581}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1894042941358002871}
+  m_Father: {fileID: 3485912562616356140}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3761537921304562981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1614913700655172968}
+  m_Layer: 9
+  m_Name: IndexFinger_04_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1614913700655172968
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3761537921304562981}
+  m_LocalRotation: {x: -0.004519649, y: -0.028039929, z: -0.15906802, w: 0.986859}
+  m_LocalPosition: {x: 0.037793327, y: -0.0000052657088, z: -0.0000001550738}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8231706724182408361}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4040955312074394376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4135177312034376942}
+  m_Layer: 9
+  m_Name: Thumb_02_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4135177312034376942
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4040955312074394376}
+  m_LocalRotation: {x: 0.06596402, y: 0.15778397, z: -0.019527182, w: -0.98507446}
+  m_LocalPosition: {x: 0.06370147, y: -0.000007788651, z: 0.0000004246831}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8866147520645510432}
+  m_Father: {fileID: 8133562697900965011}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4198919252129249676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2376984514544650451}
+  m_Layer: 9
+  m_Name: IndexFinger_01_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2376984514544650451
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4198919252129249676}
+  m_LocalRotation: {x: -0.001012347, y: -0.07592192, z: -0.010044581, w: 0.99706274}
+  m_LocalPosition: {x: -0.1039656, y: 0.003987163, z: 0.026726495}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3522733748536472985}
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4279222585773830940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4102763175617531100}
+  m_Layer: 9
+  m_Name: IndexFinger_02_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4102763175617531100
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4279222585773830940}
+  m_LocalRotation: {x: 0.042210087, y: 0.0030954692, z: -0.30917105, w: -0.95006424}
+  m_LocalPosition: {x: 0.040935885, y: 0.00000092282426, z: -0.000000056810677}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8231706724182408361}
+  m_Father: {fileID: 6136246589827452661}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4291142348403493352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6128391349511711873}
+  m_Layer: 9
+  m_Name: Prop_Attachment_Extra2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6128391349511711873
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4291142348403493352}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8085173571690234859}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4436255636361755776
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4436255636361755777}
+  m_Layer: 11
+  m_Name: Riposter Standing Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4436255636361755777
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4436255636361755776}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.05, y: 0, z: 0.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 764030083}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4436255637133151645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4436255637133151642}
+  - component: {fileID: 4436255637133151641}
+  - component: {fileID: 4436255637133151640}
+  - component: {fileID: 4436255637133151643}
+  m_Layer: 12
+  m_Name: Riposte Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4436255637133151642
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4436255637133151645}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.2, z: 0.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 75989252}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &4436255637133151641
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4436255637133151645}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &4436255637133151640
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4436255637133151645}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.43480468, y: 0.73867637, z: 0.049798608}
+  m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.061731517}
+--- !u!114 &4436255637133151643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4436255637133151645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  criticalDamagerStandPosition: {fileID: 4436255636361755777}
+--- !u!1 &4464446710849349632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1894042941358002871}
+  m_Layer: 9
+  m_Name: Toes_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1894042941358002871
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4464446710849349632}
+  m_LocalRotation: {x: 0.00000026481644, y: -0.7071068, z: 0.00000026481635, w: 0.7071068}
+  m_LocalPosition: {x: 0.0729575, y: -7.3880635e-10, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4935603886607176230}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4480730405454973189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8105977730227632447}
+  m_Layer: 9
+  m_Name: Finger_03_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8105977730227632447
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4480730405454973189}
+  m_LocalRotation: {x: 0.0054590213, y: -0.030513607, z: 0.4087086, w: 0.91213846}
+  m_LocalPosition: {x: -0.03513328, y: 0.000000037740392, z: 0.0000000010732037}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6091700693805221158}
+  m_Father: {fileID: 6733491399004700290}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4535405071732743722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5244018147658018127}
+  m_Layer: 9
+  m_Name: Finger_02_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5244018147658018127
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4535405071732743722}
+  m_LocalRotation: {x: -0.022789175, y: -0.016550567, z: -0.3618357, w: -0.9318164}
+  m_LocalPosition: {x: 0.042488072, y: 0.00000028777868, z: -0.000000016763806}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2106425848123096552}
+  m_Father: {fileID: 4922087436607844220}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4684622285505349226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5076680852144699720}
+  m_Layer: 9
+  m_Name: Eyes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5076680852144699720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4684622285505349226}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.09271572, z: 0.12272215}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6472099338095951124}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4924326665113970085
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6136246589827452661}
+  m_Layer: 9
+  m_Name: IndexFinger_01_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6136246589827452661
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4924326665113970085}
+  m_LocalRotation: {x: -0.013495237, y: 0.12788932, z: 0.020216519, w: -0.9914906}
+  m_LocalPosition: {x: 0.10396602, y: -0.0039899843, z: -0.026726522}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4102763175617531100}
+  m_Father: {fileID: 1124239235835893587}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4938113985771222113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3543380861444069851}
+  m_Layer: 9
+  m_Name: Fx_Attachment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3543380861444069851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4938113985771222113}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8085173571690234859}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5053067787365451783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3278199954002114090}
+  m_Layer: 9
+  m_Name: Finger_04_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3278199954002114090
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5053067787365451783}
+  m_LocalRotation: {x: 0.01664637, y: 0.096525334, z: -0.16913006, w: 0.98071444}
+  m_LocalPosition: {x: 0.03003113, y: 0.0000011334713, z: 0.0000003591099}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2106425848123096552}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5109808197458273154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512073418717577140}
+  m_Layer: 9
+  m_Name: LowerLeg_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1512073418717577140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5109808197458273154}
+  m_LocalRotation: {x: 0.69640523, y: 0.046938326, z: -0.030142298, w: 0.7154775}
+  m_LocalPosition: {x: -0.39930907, y: 0.000000059604645, z: 1.2738255e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3243923388340897948}
+  m_Father: {fileID: 4511584776602957073}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5146695280644176498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1152179737579750028}
+  m_Layer: 9
+  m_Name: Spine_02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1152179737579750028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5146695280644176498}
+  m_LocalRotation: {x: 0.9948446, y: -0.09800402, z: -0.019615274, w: 0.01716675}
+  m_LocalPosition: {x: -0.18151172, y: -0.000000029802322, z: 0.000000013969839}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5338167718811397838}
+  - {fileID: 2189733746538761995}
+  m_Father: {fileID: 3725265733891815479}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5159714046687888750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2106425848123096552}
+  m_Layer: 9
+  m_Name: Finger_03_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2106425848123096552
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5159714046687888750}
+  m_LocalRotation: {x: -0.005326134, y: 0.030390467, z: -0.40430483, w: -0.9141038}
+  m_LocalPosition: {x: 0.03513327, y: -0.00000014156103, z: 0.0000000144355}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3278199954002114090}
+  m_Father: {fileID: 5244018147658018127}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5195258590193363467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9081966979823668343}
+  m_Layer: 9
+  m_Name: Hips
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9081966979823668343
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5195258590193363467}
+  m_LocalRotation: {x: 0.4644048, y: -0.533213, z: -0.45846716, w: 0.5383493}
+  m_LocalPosition: {x: 0.0014336109, y: 0.9057569, z: -0.025198698}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4057642882953903936}
+  - {fileID: 3725265733891815479}
+  - {fileID: 8496984858403547758}
+  - {fileID: 4511584776602957073}
+  m_Father: {fileID: 8085173571690234859}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5232326834900128812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4511584776602957073}
+  m_Layer: 9
+  m_Name: UpperLeg_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4511584776602957073
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5232326834900128812}
+  m_LocalRotation: {x: 0.056999438, y: 0.7304186, z: -0.6803029, w: -0.020682381}
+  m_LocalPosition: {x: 0.041157685, y: -0.026920708, z: -0.09896705}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1512073418717577140}
+  m_Father: {fileID: 9081966979823668343}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5329917998478383509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1124239235835893587}
+  - component: {fileID: 1871442321}
+  m_Layer: 9
+  m_Name: Hand_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1124239235835893587
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5329917998478383509}
+  m_LocalRotation: {x: -0.15530588, y: -0.07220194, z: -0.03288075, w: 0.9846755}
+  m_LocalPosition: {x: 0.27114487, y: -0.00000003259629, z: 0.00038135424}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4922087436607844220}
+  - {fileID: 6136246589827452661}
+  - {fileID: 1151903930797022105}
+  - {fileID: 8133562697900965011}
+  m_Father: {fileID: 1590882301947647278}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1871442321
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2241,3 +2410,610 @@ MonoBehaviour:
   isBackSlot: 0
   currentWeapon: {fileID: 0}
   currentWeaponModel: {fileID: 0}
+--- !u!1 &5394572765471831356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3227778546943542901}
+  m_Layer: 9
+  m_Name: LowerLeg_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3227778546943542901
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5394572765471831356}
+  m_LocalRotation: {x: 0.6410804, y: 0.065192334, z: -0.04350663, w: 0.7634613}
+  m_LocalPosition: {x: 0.39930925, y: -0.00000035762787, z: -1.2739676e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3485912562616356140}
+  m_Father: {fileID: 8496984858403547758}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5400107725386525243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 232910987196197086}
+  m_Layer: 9
+  m_Name: Prop_Attachment_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &232910987196197086
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5400107725386525243}
+  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
+  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5544456228078078450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7766478588371078427}
+  m_Layer: 9
+  m_Name: Prop_Attachment_Extra1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7766478588371078427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5544456228078078450}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8085173571690234859}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5695338204867469968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 922387819355016208}
+  m_Layer: 9
+  m_Name: Thumb_01_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &922387819355016208
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5695338204867469968}
+  m_LocalRotation: {x: 0.10272303, y: 0.13435821, z: 0.3131672, w: 0.934517}
+  m_LocalPosition: {x: -0.035140503, y: -0.011706891, z: 0.04505539}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 167885150368866334}
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5752860457072063705
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8866147520645510432}
+  m_Layer: 9
+  m_Name: Thumb_03_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8866147520645510432
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5752860457072063705}
+  m_LocalRotation: {x: 0.042597283, y: 0.25559175, z: 0.23750533, w: -0.9361888}
+  m_LocalPosition: {x: 0.056655083, y: 0.00000007264316, z: -0.00000021979213}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4135177312034376942}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5758197421546366878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6733491399004700290}
+  m_Layer: 9
+  m_Name: Finger_02_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6733491399004700290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5758197421546366878}
+  m_LocalRotation: {x: 0.022871796, y: 0.016431663, z: 0.36629796, w: 0.9300714}
+  m_LocalPosition: {x: -0.04248817, y: -0.000000023621396, z: 0.0000000010913936}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8105977730227632447}
+  m_Father: {fileID: 7090875665751363661}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5857390405233763194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8231706724182408361}
+  m_Layer: 9
+  m_Name: IndexFinger_03_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8231706724182408361
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5857390405233763194}
+  m_LocalRotation: {x: 0.044269163, y: 0.022257227, z: -0.15307403, w: -0.98697174}
+  m_LocalPosition: {x: 0.037912127, y: 0.000003280118, z: -0.00000005029142}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1614913700655172968}
+  m_Father: {fileID: 4102763175617531100}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6579273708586863148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8085173571690234859}
+  m_Layer: 9
+  m_Name: Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8085173571690234859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6579273708586863148}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3543380861444069851}
+  - {fileID: 9081966979823668343}
+  - {fileID: 7766478588371078427}
+  - {fileID: 6128391349511711873}
+  m_Father: {fileID: 1640732483817173713}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6914888132652031746
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1590882301947647278}
+  m_Layer: 9
+  m_Name: Elbow_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1590882301947647278
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6914888132652031746}
+  m_LocalRotation: {x: -0.109417275, y: 0.22795282, z: 0.024202544, w: 0.96720195}
+  m_LocalPosition: {x: 0.3394746, y: 0.0014476385, z: 0.0014362596}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1124239235835893587}
+  m_Father: {fileID: 3899419159179878535}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6977892974847846257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8133562697900965011}
+  m_Layer: 9
+  m_Name: Thumb_01_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8133562697900965011
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6977892974847846257}
+  m_LocalRotation: {x: -0.11694848, y: -0.1735315, z: -0.35610104, w: -0.9107151}
+  m_LocalPosition: {x: 0.035139985, y: 0.011709997, z: -0.045055427}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4135177312034376942}
+  m_Father: {fileID: 1124239235835893587}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6998937633247219091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 792284055194252288}
+  m_Layer: 9
+  m_Name: Clavicle_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &792284055194252288
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6998937633247219091}
+  m_LocalRotation: {x: -0.5020848, y: 0.6266735, z: -0.4337061, w: -0.40876657}
+  m_LocalPosition: {x: -0.058011726, y: -0.041914478, z: -0.07447154}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 361101427359601872}
+  m_Father: {fileID: 5338167718811397838}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7410106210699363737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7307991656503276540}
+  m_Layer: 9
+  m_Name: Eyebrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7307991656503276540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7410106210699363737}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.1276692, z: 0.12272215}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6472099338095951124}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7499945892767173451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7573790231232397362}
+  m_Layer: 9
+  m_Name: Elbow_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7573790231232397362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7499945892767173451}
+  m_LocalRotation: {x: -0.09152292, y: 0.2011993, z: 0.034261495, w: 0.9746633}
+  m_LocalPosition: {x: -0.33947405, y: -0.0014491217, z: -0.0014362646}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2681769484870082267}
+  m_Father: {fileID: 361101427359601872}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7686126152137597170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3243923388340897948}
+  m_Layer: 9
+  m_Name: Ankle_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3243923388340897948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7686126152137597170}
+  m_LocalRotation: {x: 0.8367191, y: 0.51112205, z: 0.121969916, w: -0.15420388}
+  m_LocalPosition: {x: -0.37712362, y: 0.00000008940697, z: -0.0000000055879354}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3314775296628987190}
+  m_Father: {fileID: 1512073418717577140}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8686854711517856627
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7090875665751363661}
+  m_Layer: 9
+  m_Name: Finger_01_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7090875665751363661
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686854711517856627}
+  m_LocalRotation: {x: -0.0033722788, y: -0.028836798, z: 0.16308427, w: 0.9861849}
+  m_LocalPosition: {x: -0.09982523, y: -0.0011595332, z: -0.0328334}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6733491399004700290}
+  m_Father: {fileID: 2681769484870082267}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8764455070884887441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3314775296628987190}
+  m_Layer: 9
+  m_Name: Ball_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3314775296628987190
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8764455070884887441}
+  m_LocalRotation: {x: -0, y: -0, z: -0.2700158, w: 0.96285594}
+  m_LocalPosition: {x: -0.1128404, y: 0.000000007450581, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8036675019150793943}
+  m_Father: {fileID: 3243923388340897948}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8934204478544436673
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4057642882953903936}
+  m_Layer: 9
+  m_Name: Hips_Attachment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4057642882953903936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8934204478544436673}
+  m_LocalRotation: {x: -0.46113664, y: 0.5360532, z: 0.46113664, w: 0.5360532}
+  m_LocalPosition: {x: -1.4210854e-16, y: 8.8817837e-17, z: 9.666941e-20}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9081966979823668343}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8998778680567323319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1151903930797022105}
+  m_Layer: 9
+  m_Name: Prop_Attachment_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1151903930797022105
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8998778680567323319}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: -4.440892e-18}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1124239235835893587}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9022855097340908822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6472099338095951124}
+  m_Layer: 9
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6472099338095951124
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9022855097340908822}
+  m_LocalRotation: {x: 0.42928478, y: -0.52979195, z: 0.49031618, w: 0.54279387}
+  m_LocalPosition: {x: -0.12164436, y: -0.000000014901161, z: 0.000000013038516}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7307991656503276540}
+  - {fileID: 5076680852144699720}
+  - {fileID: 5725917375320580103}
+  m_Father: {fileID: 596899668138413448}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Data/Prefabs/Player.prefab
+++ b/Assets/Data/Prefabs/Player.prefab
@@ -60,6 +60,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 845970431}
+  - {fileID: 229186707522473095}
   m_Father: {fileID: 4086121375157841862}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -150,7 +151,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 845970430}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.75}
+  m_LocalPosition: {x: -0.05, y: 0, z: -0.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -300,6 +301,7 @@ Transform:
   m_Children:
   - {fileID: 521008669}
   - {fileID: 1974401909}
+  - {fileID: 229186707484642017}
   m_Father: {fileID: 4086121375157841862}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -314,7 +316,7 @@ GameObject:
   - component: {fileID: 1974401909}
   - component: {fileID: 1974401912}
   - component: {fileID: 1974401910}
-  - component: {fileID: 1974401913}
+  - component: {fileID: 229186707681697945}
   m_Layer: 12
   m_Name: BackStab Collider
   m_TagString: Untagged
@@ -366,7 +368,7 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.43480468, y: 0.73867637, z: 0.0037221909}
   m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.084769726}
---- !u!114 &1974401913
+--- !u!114 &229186707681697945
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -375,10 +377,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1974401908}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 470f95bf7dfa9bb498a9ebd6a3b87073, type: 3}
+  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  backStabberStandPoint: {fileID: 845970431}
+  criticalDamagerStandPosition: {fileID: 845970431}
 --- !u!1 &117870595554731890
 GameObject:
   m_ObjectHideFlags: 0
@@ -442,6 +444,158 @@ Transform:
   m_Father: {fileID: 428153540147685243}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &229186707484642018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 229186707484642017}
+  - component: {fileID: 229186707484642022}
+  - component: {fileID: 229186707484642023}
+  - component: {fileID: 229186707484642016}
+  m_Layer: 13
+  m_Name: Riposte Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &229186707484642017
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707484642018}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.2, z: 0.148}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1481502053}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &229186707484642022
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707484642018}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &229186707484642023
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707484642018}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.43480468, y: 0.73867637, z: 0.039147377}
+  m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.06705713}
+--- !u!114 &229186707484642016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707484642018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  criticalDamagerStandPosition: {fileID: 229186707522473095}
+--- !u!1 &229186707522473088
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 229186707522473095}
+  m_Layer: 11
+  m_Name: Riposter Standing Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &229186707522473095
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707522473088}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.05, y: 0, z: 0.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 456356398}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &229186707690818934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 229186707690818933}
+  - component: {fileID: 229186707690818932}
+  m_Layer: 11
+  m_Name: Jump Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &229186707690818933
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707690818934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.223, z: 0.109}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4086121375157841862}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &229186707690818932
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229186707690818934}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 0.009197041}
+  m_Center: {x: 0, y: 0, z: 0.045401476}
 --- !u!1 &493989060429831774
 GameObject:
   m_ObjectHideFlags: 0
@@ -1587,8 +1741,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4086121375157841863}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 10, z: -11.6}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.5, y: 0, z: -15}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1597,6 +1751,7 @@ Transform:
   - {fileID: 1481502053}
   - {fileID: 1272130788}
   - {fileID: 456356398}
+  - {fileID: 229186707690818933}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1697,8 +1852,10 @@ MonoBehaviour:
   movementSpeed: 5
   walkingSpeed: 1
   sprintSpeed: 7
-  rotationSpeed: 10
+  rotationSpeed: 18
   fallingSpeed: 700
+  rollStaminaCost: 15
+  jumpCollider: {fileID: 229186707690818932}
 --- !u!114 &4086121375157841885
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1712,8 +1869,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   lockOnTransform: {fileID: 199501606}
-  backStabBoxCollider: {fileID: 1974401910}
-  backStabCollider: {fileID: 1974401910}
+  backStabCollider: {fileID: 229186707681697945}
+  riposteCollider: {fileID: 229186707484642016}
+  canBeRiposted: 0
   pendingCriticalDamage: 0
   isInteracting: 0
   interactableUIGameObject: {fileID: 0}
@@ -1737,12 +1895,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd0ae6b8856022145bf0feb555aa8df3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  rightWeapon: {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
+  rightWeapon: {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
   leftWeapon: {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
   unarmedWeapon: {fileID: 11400000, guid: 1988c26deec11134fbe97c2b980264fb, type: 2}
   currentSpell: {fileID: 11400000, guid: f3b84f19fd13e2548a205efbbc7a1796, type: 2}
   weaponsInRightHandSlots:
-  - {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
+  - {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
   - {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
   weaponsInLeftHandSlots:
   - {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
@@ -1771,6 +1929,7 @@ MonoBehaviour:
   focusLevel: 10
   maxFocus: 0
   currentFocus: 0
+  soulCount: 0
   isDead: 0
   staminaRegenerationAmount: 20
   staminaRegenerationTimer: 0
@@ -2714,7 +2873,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9045528541365551196}
   m_LocalRotation: {x: 0.4644048, y: -0.533213, z: -0.45846716, w: 0.5383493}
-  m_LocalPosition: {x: 0.0014336109, y: 0.90575695, z: -0.025197983}
+  m_LocalPosition: {x: 0.0014336109, y: 0.9057569, z: -0.025198936}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -650,56 +650,22 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &720961317
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 720961318}
-  - component: {fileID: 720961319}
-  m_Layer: 11
-  m_Name: Jump Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &720961318
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 720961317}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.223, z: 0.109}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 940673487}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &720961319
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 720961317}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 0.009197041}
-  m_Center: {x: 0, y: 0, z: 0.045401476}
 --- !u!4 &940673487 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-  m_PrefabInstance: {fileID: 4086121375561442825}
+  m_PrefabInstance: {fileID: 229186706998293075}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &940673493 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4086121375157841884, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+  m_PrefabInstance: {fileID: 229186706998293075}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd0ae6b8856022145bf0feb555aa8df3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1597,6 +1563,79 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 149b3944685fe904dbecc8bbece03fb2, type: 3}
+--- !u!1001 &229186706998293075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 229186707484642017, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841863, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: canBeRiposted
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: interactableUIGameObject
+      value: 
+      objectReference: {fileID: 2974136226460140116}
+    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+      propertyPath: itemInteractableGameObject
+      value: 
+      objectReference: {fileID: 531297714}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
 --- !u!1001 &999547179008513038
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1654,63 +1693,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
---- !u!1001 &1247414621721429469
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.56
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 360
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
-      propertyPath: m_Name
-      value: Enemy
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
 --- !u!1 &2974136226448954749 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 895805934, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
@@ -1766,122 +1748,99 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1001 &4086121375561442825
+--- !u!1001 &4436255635672414830
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2545771709573109894, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
+    - target: {fileID: 367362761, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2545771709573109894, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
+    - target: {fileID: 634820070, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: pursueTargetState
+      value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 724058275, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 764030082, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1269662333, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1288313292, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -15
+      value: -1.56
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: -1
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 360
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841862, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841863, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_Name
-      value: Player
+      value: Enemy
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841883, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: jumpCollider
-      value: 
-      objectReference: {fileID: 720961319}
-    - target: {fileID: 4086121375157841883, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: rotationSpeed
-      value: 18
+    - target: {fileID: 4436255636361755776, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Layer
+      value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841884, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: rightWeapon
-      value: 
-      objectReference: {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
-    - target: {fileID: 4086121375157841884, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: weaponsInRightHandSlots.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
-    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: backStabCollider
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: pendingCriticalDamage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: interactableUIGameObject
-      value: 
-      objectReference: {fileID: 2974136226460140116}
-    - target: {fileID: 4086121375157841885, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: itemInteractableGameObject
-      value: 
-      objectReference: {fileID: 531297714}
-    - target: {fileID: 5447324443903944224, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.9057569
-      objectReference: {fileID: 0}
-    - target: {fileID: 5447324443903944224, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    - target: {fileID: 4436255637133151642, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.025198936
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4436255637133151645, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
---- !u!114 &4086121375561442826 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4086121375157841884, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-  m_PrefabInstance: {fileID: 4086121375561442825}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fd0ae6b8856022145bf0feb555aa8df3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_SourcePrefab: {fileID: 100100000, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
 --- !u!4 &6450411920818120557 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
@@ -2025,7 +1984,7 @@ PrefabInstance:
     - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
       propertyPath: playerInventory
       value: 
-      objectReference: {fileID: 4086121375561442826}
+      objectReference: {fileID: 940673493}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
 --- !u!224 &8201319159866344364 stripped

--- a/Assets/Scripts/AI/EnemyManager.cs
+++ b/Assets/Scripts/AI/EnemyManager.cs
@@ -29,7 +29,7 @@ namespace sg {
             enemyStats = GetComponent<EnemyStats>();
             navmeshAgent = GetComponentInChildren<NavMeshAgent>();
             enemyRigidbody = GetComponent<Rigidbody>();
-            backStabCollider = GetComponentInChildren<BackStabCollider>();
+            backStabCollider = GetComponentInChildren<CriticalDamageCollider>();
             navmeshAgent.enabled = false;
         }
 

--- a/Assets/Scripts/BackStabCollider.cs
+++ b/Assets/Scripts/BackStabCollider.cs
@@ -1,9 +1,0 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace sg {
-    public class BackStabCollider : MonoBehaviour {
-        public Transform backStabberStandPoint;
-    }
-}

--- a/Assets/Scripts/CriticalDamageCollider.cs
+++ b/Assets/Scripts/CriticalDamageCollider.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace sg {
+    public class CriticalDamageCollider : MonoBehaviour {
+        public Transform criticalDamagerStandPosition;
+    }
+}

--- a/Assets/Scripts/Managers/CharacterManager.cs
+++ b/Assets/Scripts/Managers/CharacterManager.cs
@@ -8,8 +8,11 @@ namespace sg {
         public Transform lockOnTransform;
 
         [Header("Comabat Colliders")]
-        public BoxCollider backStabBoxCollider;
-        public BackStabCollider backStabCollider;
+        public CriticalDamageCollider backStabCollider;
+        public CriticalDamageCollider riposteCollider;
+
+        [Header("Combat Flags")]
+        public bool canBeRiposted;
 
         // 데미지는 애니메이션 이벤트로 가해질 것
         public float pendingCriticalDamage;

--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -31,7 +31,7 @@ namespace sg {
             playerAnimatorManager = GetComponentInChildren<PlayerAnimatorManager>();
             cameraHandler = FindObjectOfType<CameraHandler>();
             playerStats = GetComponent<PlayerStats>();
-            backStabCollider = GetComponentInChildren<BackStabCollider>();
+            backStabCollider = GetComponentInChildren<CriticalDamageCollider>();
             inputHandler = GetComponent<InputHandler>();
             anim = GetComponentInChildren<Animator>();
             playerLocomotion = GetComponent<PlayerLocomotion>();

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -22,7 +22,7 @@ TagManager:
   - Character Collider Blocker
   - Player
   - BackStab
-  - 
+  - Riposte
   - 
   - 
   - 


### PR DESCRIPTION
# Player GameObject + Enemy GameObject
- 앞잡용 Collider를 가지는 GameObject를 자식으로 추가
- 앞잡을 하는 상대의 좌표를 강제할 GameObject를 자식으로 추가

# CharacterManager
- 앞잡용 Collider 추가
- 앞잡이 가능한지 불가능한지 저장할 변수

# PlayerAttacker
- RayCast로 레이어를 식별해서 앞잡을 수행한다.
- BackStab과 동일