### PR TITLE
방어력 적용

### DIFF
--- a/Assets/Data/Items/Equipments/Knight's ChestPlate.asset
+++ b/Assets/Data/Items/Equipments/Knight's ChestPlate.asset
@@ -14,6 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemIcon: {fileID: 0}
   itemName: Knight's ChestPlate
-  physicalDefense: 0
+  physicalDefense: 12.5
   torsoModelName: PT_Male_Armor_01_A_body
   capeModelName: PT_Male_Armor_01_A_cape

--- a/Assets/Data/Items/Equipments/Knight's Guntlet.asset
+++ b/Assets/Data/Items/Equipments/Knight's Guntlet.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemIcon: {fileID: 0}
   itemName: Knight's Guntlet
-  physicalDefense: 0
+  physicalDefense: 6.5
   guntletModelName: PT_Male_Armor_01_A_gauntlets

--- a/Assets/Data/Items/Equipments/Knight's Helmet.asset
+++ b/Assets/Data/Items/Equipments/Knight's Helmet.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemIcon: {fileID: 0}
   itemName: Knight's Helmet
-  physicalDefense: 0
+  physicalDefense: 7
   helmetModelName: PT_Male_Armor_01_A_helmet

--- a/Assets/Data/Items/Equipments/Knight's Leg Armor.asset
+++ b/Assets/Data/Items/Equipments/Knight's Leg Armor.asset
@@ -14,6 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemIcon: {fileID: 0}
   itemName: Knight's Leg Armor
-  physicalDefense: 0
+  physicalDefense: 10
   legModelName: PT_Male_Armor_01_A_legs
   bootsModelName: PT_Male_Armor_01_A_boots

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2055,6 +2055,10 @@ MonoBehaviour:
   maxFocus: 0
   currentFocus: 0
   soulCount: 0
+  physicalDamageAbsorptionHead: 0
+  physicalDamageAbsorptionBody: 0
+  physicalDamageAbsorptionLegs: 0
+  physicalDamageAbsorptionHands: 0
   isDead: 0
   healthBar: {fileID: 580179355}
   staminaBar: {fileID: 599826540}
@@ -2117,10 +2121,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: afec93e198cf13042ba1053339d24b29, type: 2}
   - {fileID: 11400000, guid: 32f44fc45c1141b4a8638938b109e01c, type: 2}
   - {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
-  currentHelmetEquipment: {fileID: 11400000, guid: 9fd0aea1c6995794a8ae5a54a1662bcf, type: 2}
-  currentTorsoEquipment: {fileID: 11400000, guid: 45e938a30804f964ab9f69c147c7b9c9, type: 2}
-  currentLegEquipment: {fileID: 11400000, guid: 73115051e8b2f47488a248e47d3fbccd, type: 2}
-  currentGuntletEquipment: {fileID: 11400000, guid: 5bdbecf98282d1148968477099f17041, type: 2}
+  currentHelmetEquipment: {fileID: 11400000, guid: fc1e36634f4ce4540be04eb96bc679c0, type: 2}
+  currentTorsoEquipment: {fileID: 11400000, guid: e67d82a93443a204090643a8bbdec9d8, type: 2}
+  currentLegEquipment: {fileID: 11400000, guid: d4d8bac998410a84594783304bc4a1f9, type: 2}
+  currentGuntletEquipment: {fileID: 11400000, guid: 47a41915e5ae5494591a6021240b8c1d, type: 2}
   currentRightWeaponIndex: 0
   currentLeftWeaponIndex: 0
   weaponsInventory: []

--- a/Assets/Scripts/AI/EnemyStats.cs
+++ b/Assets/Scripts/AI/EnemyStats.cs
@@ -33,8 +33,8 @@ namespace sg {
         }
 
         public override void TakeDamage(float damage, string damageAnimation = "Damage") {
-            if (isDead) return;
-            currentHealth -= damage;
+            base.TakeDamage(damage, damageAnimation = "Damage");
+            
             enemyHealthBar.SetHealth(currentHealth);
             enemyAnimatorManager.PlayTargetAnimation(damageAnimation, true);
 

--- a/Assets/Scripts/Items/Equipment/PlayerEquipmentManager.cs
+++ b/Assets/Scripts/Items/Equipment/PlayerEquipmentManager.cs
@@ -14,6 +14,7 @@ namespace sg {
         BootsModelChanger bootsModelChanger;
         GuntletModelChanger guntletModelChanger;
         CapeModelChanger capeModelChanger;
+        PlayerStats playerStats;
 
         [Header("Default Naked Models")]
         //public GameObject nakedHeadModel;
@@ -35,7 +36,9 @@ namespace sg {
             bootsModelChanger = GetComponentInChildren<BootsModelChanger>();
             guntletModelChanger = GetComponentInChildren<GuntletModelChanger>();
             capeModelChanger = GetComponentInChildren<CapeModelChanger>();
+            playerStats = GetComponentInParent<PlayerStats>();
         }
+
 
         private void Start() {
             EquipAllEquipmentModelsOnStart();
@@ -46,9 +49,12 @@ namespace sg {
             if (playerInventory.currentHelmetEquipment != null) {
                 //nakedHeadModel.SetActive(false);
                 helmetModelChanger.EquipHelmetModelByName(playerInventory.currentHelmetEquipment.helmetModelName);
+                playerStats.physicalDamageAbsorptionHead = playerInventory.currentHelmetEquipment.physicalDefense;
+                Debug.Log("Head Absorption : " + playerStats.physicalDamageAbsorptionHead + "%");
             } else {
                 //nakedHeadModel.SetActive(true);
                 helmetModelChanger.EquipHelmetModelByName(nakedHeadModel);
+                playerStats.physicalDamageAbsorptionHead = 0;
             }
 
             torsoModelChanger.UnEquipAllTorsoModels();
@@ -56,9 +62,12 @@ namespace sg {
             if (playerInventory.currentTorsoEquipment != null) {
                 torsoModelChanger.EquipTorsoModelByName(playerInventory.currentTorsoEquipment.torsoModelName);
                 capeModelChanger.EquipCapeModelByName(playerInventory.currentTorsoEquipment.capeModelName);
+                playerStats.physicalDamageAbsorptionBody = playerInventory.currentTorsoEquipment.physicalDefense;
+                Debug.Log("Body Absorption : " + playerStats.physicalDamageAbsorptionBody + "%");
             } else {
                 torsoModelChanger.EquipTorsoModelByName(nakedTorsoModel);
                 capeModelChanger.EquipCapeModelByName(nakedCapeModel);
+                playerStats.physicalDamageAbsorptionBody = 0;
             }
 
             legModelChanger.UnEquipAllLegModels();
@@ -66,16 +75,22 @@ namespace sg {
             if (playerInventory.currentLegEquipment != null) {
                 legModelChanger.EquipLegModelByName(playerInventory.currentLegEquipment.legModelName);
                 bootsModelChanger.EquipBootsModelByName(playerInventory.currentLegEquipment.bootsModelName);
+                playerStats.physicalDamageAbsorptionLegs = playerInventory.currentLegEquipment.physicalDefense;
+                Debug.Log("Legs Absorption : " + playerStats.physicalDamageAbsorptionLegs + "%");
             } else {
                 legModelChanger.EquipLegModelByName(nakedLegModel);
                 bootsModelChanger.EquipBootsModelByName(nakedBootsModel);
+                playerStats.physicalDamageAbsorptionLegs = 0;
             }
 
             guntletModelChanger.UnEquipAllGuntletModels();
             if (playerInventory.currentGuntletEquipment != null) {
                 guntletModelChanger.EquipGuntletModelByName(playerInventory.currentGuntletEquipment.guntletModelName);
+                playerStats.physicalDamageAbsorptionHands = playerInventory.currentGuntletEquipment.physicalDefense;
+                Debug.Log("Hands Absorption : " + playerStats.physicalDamageAbsorptionHands + "%");
             } else {
                 guntletModelChanger.EquipGuntletModelByName(nakedGuntletModel);
+                playerStats.physicalDamageAbsorptionHands = 0;
             }
         }
 

--- a/Assets/Scripts/Managers/CharacterStats.cs
+++ b/Assets/Scripts/Managers/CharacterStats.cs
@@ -18,10 +18,28 @@ namespace sg {
 
         public int soulCount = 0;
 
+        [Header("Armor Absorptions")]
+        public float physicalDamageAbsorptionHead;
+        public float physicalDamageAbsorptionBody;
+        public float physicalDamageAbsorptionLegs;
+        public float physicalDamageAbsorptionHands;
+
         public bool isDead;
 
-        public virtual void TakeDamage(float damage, string damageAnimation = "Damage") {
-        
+        public virtual void TakeDamage(float physicalDamage, string damageAnimation = "Damage") {
+            if (isDead) return;
+
+            float totalPhysicalDamageAbsorption = 1 - (1 - physicalDamageAbsorptionHead / 100) * (1 - physicalDamageAbsorptionBody / 100) * (1 - physicalDamageAbsorptionLegs / 100) * (1 - physicalDamageAbsorptionHands / 100);
+            physicalDamage -= (physicalDamage * totalPhysicalDamageAbsorption);
+            Debug.Log("Total Physical Damage Absorption is " + totalPhysicalDamageAbsorption + "%");
+            float finalDamage = physicalDamage;
+            currentHealth -= finalDamage;
+            Debug.Log("Total Damage Dealt is " + finalDamage);
+
+            if (currentHealth <= 0) {
+                currentHealth = 0;
+                isDead = true;
+            }
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerStats.cs
+++ b/Assets/Scripts/Player/PlayerStats.cs
@@ -55,15 +55,16 @@ namespace sg {
 
         public override void TakeDamage(float damage, string damageAnimation = "Damage") {
             if (playerManager.isInvulnerable) return;
-            if (isDead) return;
-            currentHealth -= damage;
+
+            base.TakeDamage(damage, damageAnimation = "Damage");
+           
             healthBar.SetCurrentHealth(currentHealth);
             animatorHandler.PlayTargetAnimation(damageAnimation, true);
 
             if (currentHealth <= 0) {
                 currentHealth = 0;
-                animatorHandler.PlayTargetAnimation("Dead", true);
                 isDead = true;
+                animatorHandler.PlayTargetAnimation("Dead", true);
                 // Dead 애니메이션은 Transition으로 Empty에 연결해놓지 않았다.
                 // Empty 에서 isInteracting 항목을 초기화 함으로써 다음 애니메이션으로 넘어갈수 있게끔 해주는데 플레이어가 죽는다면 그럴필요 없음
             }


### PR DESCRIPTION
# CharacterStats
- 갑옷 부분별 물리 감쇄율(%)들을 저장할 변수
- TakeDamage 함수에서 각 파츠별 감쇄율에 따른 최종 데미지 계산, 플레이어에게 적용

# PlayerStats, EnemyStats
- 데미지를 계산을 부모 클래스의 메서드로 이동

# PlayerEquipmentManager
- EquipmentItem 에는 방어력을 저장하는 변수가 존재
- 방어구를 장착하게되면 각 파츠별로 방어력을 적용