### PR TITLE
적 전투자세

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -116,9 +116,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.7115385
+  m_TransitionDuration: 0.053271532
+  m_TransitionOffset: 0.0045977267
+  m_ExitTime: 0.9191695
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -564,7 +564,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Turn_Behind
-  m_Speed: 1
+  m_Speed: 1.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 6669629878015483904}
@@ -2002,9 +2002,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.73214287
+  m_TransitionDuration: 0.060344875
+  m_TransitionOffset: 0.004862969
+  m_ExitTime: 0.9197139
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -2043,7 +2043,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Turn_Left
-  m_Speed: 1
+  m_Speed: 1.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1254630954505735137}
@@ -2336,7 +2336,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Turn_Right
-  m_Speed: 1
+  m_Speed: 1.2
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8483059051188234206}
@@ -2871,7 +2871,7 @@ AnimatorStateTransition:
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0.031166911
-  m_TransitionOffset: 0.019451817
+  m_TransitionOffset: 0
   m_ExitTime: 0.9610414
   m_HasExitTime: 1
   m_HasFixedDuration: 1

--- a/Assets/Attack 01.asset
+++ b/Assets/Attack 01.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   canCombo: 1
   comboAction: {fileID: 11400000, guid: 714b0ac9bb0c6a84f80addfe12aca049, type: 2}
   attackScore: 3
-  recoveryTime: 2
+  recoveryTime: 4
   maximumAttackAngle: 35
   minimumAttackAngle: -35
   minimumDistanceNeededToAttack: 0
-  maximumDistanceNeededToAttack: 3
+  maximumDistanceNeededToAttack: 1.5

--- a/Assets/Attack 02.asset
+++ b/Assets/Attack 02.asset
@@ -14,10 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   actionAnimation: DaggerAttack2
   canCombo: 0
-  comboAction: {fileID: 0}
+  comboAction: {fileID: 11400000}
   attackScore: 3
   recoveryTime: 2
   maximumAttackAngle: 35
   minimumAttackAngle: -35
   minimumDistanceNeededToAttack: 0
-  maximumDistanceNeededToAttack: 3
+  maximumDistanceNeededToAttack: 1.5

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -368,6 +368,17 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 93841444}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &173474184 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 634820070, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 4436255635672414830}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e4da985b6209e9418bdec8ce0602eff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &227297291
 GameObject:
   m_ObjectHideFlags: 0
@@ -530,6 +541,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: faf3ab124fae898429ca1c40629fb0e1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  combatStanceState: {fileID: 4436255635672414832}
 --- !u!1 &529954939
 GameObject:
   m_ObjectHideFlags: 0
@@ -2451,6 +2463,7 @@ MonoBehaviour:
   isParrying: 0
   isBlocking: 0
   isRotatingWithRootMotion: 0
+  canRotate: 0
   isFiringSpell: 0
   pendingCriticalDamage: 0
   isInteracting: 0
@@ -10224,10 +10237,34 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 367362763, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: rotateTowardsTargetState
+      value: 
+      objectReference: {fileID: 448874413}
     - target: {fileID: 696167646, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: slider
       value: 
       objectReference: {fileID: 696167647}
+    - target: {fileID: 724058277, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: pursueTargetState
+      value: 
+      objectReference: {fileID: 4436255635672414833}
+    - target: {fileID: 724058277, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: rotateTowardsTargetState
+      value: 
+      objectReference: {fileID: 448874413}
+    - target: {fileID: 1269662335, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: enemyAttacks.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1269662335, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: enemyAttacks.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 12b6f39ee5c982244af284ea102c8a17, type: 2}
+    - target: {fileID: 1269662335, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: enemyAttacks.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 714b0ac9bb0c6a84f80addfe12aca049, type: 2}
     - target: {fileID: 1360540455, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: mainCamera
       value: 
@@ -10243,11 +10280,15 @@ PrefabInstance:
     - target: {fileID: 1735633484, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: currentState
       value: 
-      objectReference: {fileID: 448874413}
+      objectReference: {fileID: 173474184}
     - target: {fileID: 1735633484, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: currentTarget
       value: 
-      objectReference: {fileID: 513322146902302465}
+      objectReference: {fileID: 0}
+    - target: {fileID: 1735633484, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: maximumAggroRadius
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1735633485, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
       propertyPath: healthLevel
       value: 10
@@ -10315,6 +10356,28 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1284695206, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
   m_PrefabInstance: {fileID: 4436255635672414830}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4436255635672414832 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1269662335, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 4436255635672414830}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4169a915cedfd1b4fb2c42fed43ad18a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4436255635672414833 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 367362763, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+  m_PrefabInstance: {fileID: 4436255635672414830}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 638c66c7461e90a40a10af78dc3b9e73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &4587899699368695801
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AI/EnemyAttackActions.cs
+++ b/Assets/Scripts/AI/EnemyAttackActions.cs
@@ -15,6 +15,6 @@ namespace sg {
         public float minimumAttackAngle = -35;
 
         public float minimumDistanceNeededToAttack = 0;
-        public float maximumDistanceNeededToAttack = 3;
+        public float maximumDistanceNeededToAttack = 1.5f;
     }
 }

--- a/Assets/Scripts/AI/EnemyManager.cs
+++ b/Assets/Scripts/AI/EnemyManager.cs
@@ -16,7 +16,7 @@ namespace sg {
         public Rigidbody enemyRigidbody;
 
         public float rotationSpeed = 15;
-        public float maximumAttackRange = 1.5f;
+        public float maximumAggroRadius = 1.5f;
         [Header("Combat Flags")]
         public bool canDoCombo;
 
@@ -50,6 +50,7 @@ namespace sg {
             isRotatingWithRootMotion = enemyAnimatorManager.anim.GetBool("isRotatingWithRootMotion");
             isInteracting = enemyAnimatorManager.anim.GetBool("isInteracting");
             canDoCombo = enemyAnimatorManager.anim.GetBool("canDoCombo");
+            canRotate = enemyAnimatorManager.anim.GetBool("canRotate");
             enemyAnimatorManager.anim.SetBool("isDead", enemyStats.isDead);
 
         }
@@ -78,7 +79,7 @@ namespace sg {
             if (currentRecoveryTime > 0) {
                 currentRecoveryTime -= Time.deltaTime;
             }
-            if (isPerformingAction) {
+            else if (isPerformingAction) {
                 if (currentRecoveryTime <= 0) {
                     isPerformingAction = false;
                 }

--- a/Assets/Scripts/AI/States/CombatStanceState.cs
+++ b/Assets/Scripts/AI/States/CombatStanceState.cs
@@ -5,29 +5,47 @@ using UnityEngine;
 namespace sg {
     public class CombatStanceState : State {
         public AttackState attackState;
+        public EnemyAttackActions[] enemyAttacks;
         public PursueTargetState pursueTargetState;
+
+        bool randomDestinationSet = false; // animator value , 수직 이동, 수평 이동 값을 조절하기 위한 bool 변수
+        float verticalMovementValue = 0;
+        float horizontalMovementValue = 0;
+
         public override State Tick(EnemyManager enemyManager, EnemyStats enemyStats, EnemyAnimatorManager enemyAnimatorManager) {
-            // 공격 사거리 확인
-            // 공격 대상 주위에서 걷거나 빙글빙글 돈다
-            // 공격 사거리 내에 들어가면 Attack State가 된다.
-            // 공격후 딜레이 상태라면 Combat Stance State로 돌아오고 타겟 주위를 배회
-            // 만약 타겟이 공격 사거리 밖으로 도망가버리면 Pursue Target State가 됨.
-            if (enemyManager.isInteracting) return this;
-            float distanceFromTarget = Vector3.Distance(enemyManager.currentTarget.transform.position, enemyManager.transform.position);
+            float distanceFromTarget = Vector3.Distance(enemyManager.currentTarget.transform.position, enemyManager.transform.position); // 타겟과의 거리
+            enemyAnimatorManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime); // 앞,뒤 이동
+            enemyAnimatorManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime); // 좌,우 이동
+            attackState.hasPerformedAttack = false; // 전투 태세 -> 플레이어가 적정 사거리 내에 있을 경우 공격 선택 -> 공격
+
+            if (enemyManager.isInteracting) {
+                enemyAnimatorManager.anim.SetFloat("Vertical", 0);
+                enemyAnimatorManager.anim.SetFloat("Horizontal", 0);
+                return this;
+            }
+
+            if (distanceFromTarget > enemyManager.maximumAggroRadius) return pursueTargetState;
+
+            if (!randomDestinationSet) {
+                randomDestinationSet = true;
+                DecideCirclingAction(enemyAnimatorManager);
+            }
+
             HandleRotateTowardsTarget(enemyManager);
 
-            if (enemyManager.isPerformingAction) {
-                enemyAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
-            }
-            if (enemyManager.currentRecoveryTime <= 0 && distanceFromTarget <= enemyManager.maximumAttackRange) {
+            // 현재 상태를 떠나기 전에 공격을 정한다.
+            // 해당 공격을 공격 상태로 전달
+            // 현재 상태에서 공격 상태로 넘어가기 전에 해야할 것은 공격을 선택하는 것
+            if (enemyManager.currentRecoveryTime <= 0 && attackState.currentAttack != null) { // 현재 공격이 선택된 상태라면 공격 상태로 전이
+                randomDestinationSet = false;
                 return attackState;
-            } else if (distanceFromTarget > enemyManager.maximumAttackRange) {
-                return pursueTargetState;
-            } else
-                return this;
+            } else { // 아니라면 공격 선택
+                GetNewAttack(enemyManager);
+            }
+            return this;
         }
+
         private void HandleRotateTowardsTarget(EnemyManager enemyManager) {
-            //Debug.Log("회전");
             // 특정 행동을 하고있다면 단순히 대상을 바라보도록 회전
             if (enemyManager.isPerformingAction) {
                 //Debug.Log("일반 회전");
@@ -40,14 +58,82 @@ namespace sg {
 
                 Quaternion targetRotation = Quaternion.LookRotation(direction);
                 enemyManager.transform.rotation = Quaternion.Slerp(enemyManager.transform.rotation, targetRotation, enemyManager.rotationSpeed / Time.deltaTime);
-            } else { // NavMeshAgent를 이용한 회전
-                //Debug.Log("NavMeshAgent를 이용한 회전");
-                //Vector3 relativeDirection = transform.InverseTransformDirection(enemyManager.navmeshAgent.desiredVelocity);
+            } else {
+                // NavMeshAgent를 이용한 회전
                 Vector3 targetVelocity = enemyManager.enemyRigidbody.velocity;
                 enemyManager.navmeshAgent.enabled = true;
                 enemyManager.navmeshAgent.SetDestination(enemyManager.currentTarget.transform.position);
                 enemyManager.enemyRigidbody.velocity = targetVelocity;
                 enemyManager.transform.rotation = Quaternion.Slerp(enemyManager.transform.rotation, enemyManager.navmeshAgent.transform.rotation, enemyManager.rotationSpeed / Time.deltaTime);
+            }
+        }
+
+        // 원을 그리며 이동할때 어떤식으로 움직일지 결정
+        private void DecideCirclingAction(EnemyAnimatorManager enemyAnimatorManager) {
+            // 원을 그리며 앞으로만 이동
+            // 원을 그리며 달림
+            // 원을 그리며 걷기 등...
+            WalkAroundTarget(enemyAnimatorManager);
+        }
+
+        // 타겟을 향해 걸어간다.
+        private void WalkAroundTarget(EnemyAnimatorManager enemyAnimatorManager) {
+            // 앞으로 이동하는 모션만 사용하기 위함
+            // 뒷걸음질을 구현하고 싶다면 범위에 음수를 포함시키면 됨
+            //verticalMovementValue = Random.Range(0, 1);
+
+            //if (verticalMovementValue <= 1 && verticalMovementValue > 0) {
+            //    verticalMovementValue = 0.5f;
+            //} else if (verticalMovementValue >= -1 && verticalMovementValue < 0) {
+            //    verticalMovementValue = -0.5f;
+            //}
+
+            verticalMovementValue = 0.5f;
+
+            horizontalMovementValue = Random.Range(-1, 1);
+            if (horizontalMovementValue <= 1 && horizontalMovementValue >= 0) {
+                horizontalMovementValue = 0.5f;
+            } else if (horizontalMovementValue >= -1 && horizontalMovementValue < 0) {
+                horizontalMovementValue = -0.5f;
+            }
+        }
+
+        // 공격 선택
+        // 거리, 각도 판단
+        private void GetNewAttack(EnemyManager enemyManager) {
+            Vector3 targetDirection = enemyManager.currentTarget.transform.position - enemyManager.transform.position;
+            float viewableAngle = Vector3.Angle(targetDirection, transform.forward);
+            float distanceFromTarget = Vector3.Distance(enemyManager.currentTarget.transform.position, transform.position);
+            
+            int maxScore = 0;
+            
+            for (int i = 0; i < enemyAttacks.Length; i++) {
+                EnemyAttackActions enemyAttackAction = enemyAttacks[i];
+
+                if (distanceFromTarget <= enemyAttackAction.maximumDistanceNeededToAttack &&
+                    distanceFromTarget >= enemyAttackAction.minimumDistanceNeededToAttack) { // 현재 목표가 공격 사거리 내에 있고
+                    if (viewableAngle <= enemyAttackAction.maximumAttackAngle && viewableAngle >= enemyAttackAction.minimumAttackAngle) { // 공격 가능한 시야각내에 있다면
+                        maxScore += enemyAttackAction.attackScore;
+                    }
+                }
+            }
+
+            int randomValue = Random.Range(0, maxScore);
+            int temporaryScore = 0;
+            for (int i = 0; i < enemyAttacks.Length; i++) {
+                EnemyAttackActions enemyAttackAction = enemyAttacks[i];
+
+                if (distanceFromTarget <= enemyAttackAction.maximumDistanceNeededToAttack &&
+                    distanceFromTarget >= enemyAttackAction.minimumDistanceNeededToAttack) {
+                    if (viewableAngle <= enemyAttackAction.maximumAttackAngle && viewableAngle >= enemyAttackAction.minimumAttackAngle) {
+                        if (attackState.currentAttack != null) return; // 이미 공격중이라면
+                        temporaryScore += enemyAttackAction.attackScore;
+
+                        if (temporaryScore > randomValue) {
+                            attackState.currentAttack = enemyAttackAction;
+                        }
+                    }
+                }
             }
         }
     }

--- a/Assets/Scripts/AI/States/RotateTowardsTargetState.cs
+++ b/Assets/Scripts/AI/States/RotateTowardsTargetState.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace sg {
     public class RotateTowardsTargetState : State {
-        CombatStanceState combatStanceState;
+        public CombatStanceState combatStanceState;
 
         public override State Tick(EnemyManager enemyManager, EnemyStats enemyStats, EnemyAnimatorManager enemyAnimatorManager) {
             enemyAnimatorManager.anim.SetFloat("Vertical", 0);
@@ -16,21 +16,25 @@ namespace sg {
             // 0 ~ 180 , -180 ~ 0 사이의 값을 반환한다.
             float viewableAngle = Vector3.SignedAngle(targetDirection, enemyManager.transform.forward, Vector3.up);
 
+            // 회전 상태에 돌입했는데 아직 공격이 다 끝나지 않았을 경우 흐름을 여기에 잡아두기 위함 
+            if (enemyManager.isInteracting) 
+                return this;
+            
             if (viewableAngle >= 100 && viewableAngle <= 180 && !enemyManager.isInteracting) {
                 enemyAnimatorManager.PlayTargetAnimationWithRootRotation("Turn_Behind", true);
-                return this;
-            } else if (viewableAngle < -100 && viewableAngle >= -180 && !enemyManager.isInteracting) {
+                return combatStanceState;
+            } else if (viewableAngle <= -101 && viewableAngle >= -180 && !enemyManager.isInteracting) { 
                 enemyAnimatorManager.PlayTargetAnimationWithRootRotation("Turn_Behind", true);
-                return this;
+                return combatStanceState;
             } else if (viewableAngle <= -45 && viewableAngle >= -100 && !enemyManager.isInteracting) {
                 enemyAnimatorManager.PlayTargetAnimationWithRootRotation("Turn_Right", true);
-                return this;
-            } else if (viewableAngle > 45 && viewableAngle < 100 && !enemyManager.isInteracting) {
+                return combatStanceState;
+            } else if (viewableAngle >= 45 && viewableAngle <= 100 && !enemyManager.isInteracting) {
                 enemyAnimatorManager.PlayTargetAnimationWithRootRotation("Turn_Left", true);
-                return this;
+                return combatStanceState;
             }
 
-            return this;
+            return combatStanceState;
         }
     }
 }

--- a/Assets/Scripts/Managers/CharacterManager.cs
+++ b/Assets/Scripts/Managers/CharacterManager.cs
@@ -19,6 +19,7 @@ namespace sg {
 
         [Header("Movement Flags")]
         public bool isRotatingWithRootMotion;
+        public bool canRotate;
 
         [Header("Spells")]
         public bool isFiringSpell;

--- a/Assets/Scripts/Managers/CharacterStats.cs
+++ b/Assets/Scripts/Managers/CharacterStats.cs
@@ -31,10 +31,10 @@ namespace sg {
 
             float totalPhysicalDamageAbsorption = 1 - (1 - physicalDamageAbsorptionHead / 100) * (1 - physicalDamageAbsorptionBody / 100) * (1 - physicalDamageAbsorptionLegs / 100) * (1 - physicalDamageAbsorptionHands / 100);
             physicalDamage -= (physicalDamage * totalPhysicalDamageAbsorption);
-            Debug.Log("Total Physical Damage Absorption is " + totalPhysicalDamageAbsorption + "%");
+            //Debug.Log("Total Physical Damage Absorption is " + totalPhysicalDamageAbsorption + "%");
             float finalDamage = physicalDamage;
             currentHealth -= finalDamage;
-            Debug.Log("Total Damage Dealt is " + finalDamage);
+            //Debug.Log("Total Damage Dealt is " + finalDamage);
 
             if (currentHealth <= 0) {
                 currentHealth = 0;


### PR DESCRIPTION
# CharacterManager
- 공격 모션중 특정 구간에서 회전이 가능함
- 이를 Animator의 bool Parameter를 이용하기 위한 변수를 생성

# EnemyManager
- maximumAggroRadius 적이 공격을 시도하는 거리를 저장하는 변수
- Animator의 bool Parameter인 canRotate 값을 CharacterManager의 canRotate 변수에 매 프레임마다 받아온다.

# EnemyAttackActions
- 적의 최대 공격 사거리 재설정

# CombatStanceState
- 전투 상태 돌입시(플레이어 발견, 플레이어 에게 피격 등) Enemy의 상태
- 공격 수행여부를 초기화해줌( 플레이어가 Enemy의 공격 반경내에 들어와 있다는 가정하에 Combat -> Attack -> Rotate -> Combat 순으로 전이되기 때문)
- 플레이어와의 거리를 측정하여 공격을 시도할 만한 거리내에 플레이어가 존재하지 않는다면 추적상태로 전이
- 공격을 시도할만한 거리내에 플레이어가 존재한다면 플레이어를 향해 원을 그리며 이동하고 수행할 공격을 선택한다.
- 공격을 이미 선택한 상태라면 움직임을 멈추고(randomDestinationSet = false) 공격 상태로 전이
- 공격을 선택하지 않았다면 공격을 선택한다.

# AttackState
- 단순히 공격을 수행하는 상태
- 플레이어와의 거리를 측정하여 공격을 시도할만한 거리내에 플레이어가 존재하지 않는다면 추적상태로 전이
- 거리내에 플레이어가 존재하고 아직 공격을 수행하지 않았다면 공격을 수행하고, 콤보 공격 수행 여부를 결정한다.
- 콤보 공격 플래그가 true이고, 공격을 수행한 상태라면 다시 AttackState를 반환하여 콤보 공격을 수행할수 있도록 한다.
- 일반적인 경우 Rotate 상태로 전이

# PursueTargetState
- 플레이어를 추적하는 상태
- 플레이어가 특정 시야각도내에 있다면 회전상태로 전이
- 플레이어가 공격을 시도해볼만한 사거리내에 있다면 전투 태세 상태로 전이

# RotateTowardsTargetState
- Enemey의 정면 방향을 기준으로 Enemy에서 플레이어 방향의 각도에 따라 회전 모션을 수행한다.