### PR TITLE
강인도

### DIFF
--- a/Assets/Scripts/AI/EnemyStats.cs
+++ b/Assets/Scripts/AI/EnemyStats.cs
@@ -39,7 +39,8 @@ namespace sg {
                 bossManager.UpdateBossHealthBar(currentHealth, maxHealth);
 
             if (currentHealth <= 0) {
-                HandleDeath();
+                currentHealth = 0;
+                isDead = true;
             }
         }
 
@@ -55,8 +56,7 @@ namespace sg {
             enemyAnimatorManager.PlayTargetAnimation(damageAnimation, true);
 
             if (currentHealth <= 0) {
-                currentHealth = 0;
-                isDead = true;
+                HandleDeath();
             }
         }
 

--- a/Assets/Scripts/AI/States/RotateTowardsTargetState.cs
+++ b/Assets/Scripts/AI/States/RotateTowardsTargetState.cs
@@ -19,7 +19,7 @@ namespace sg {
             if (enemyManager.isInteracting) 
                 return this;
             
-            Debug.Log(viewableAngle);
+            //Debug.Log(viewableAngle);
             if (viewableAngle >= 100 && viewableAngle <= 180 && !enemyManager.isInteracting) {
                 enemyAnimatorManager.PlayTargetAnimationWithRootRotation("Turn_Behind_Left", true);
                 return combatStanceState;

--- a/Assets/Scripts/Items/Weapons/DamageCollider.cs
+++ b/Assets/Scripts/Items/Weapons/DamageCollider.cs
@@ -2,13 +2,19 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-// 각각의 무기가 가지고 있을 Collider의 스크립트
+// 모든 무기가 가지고 있을 클래스
 namespace sg {
     public class DamageCollider : MonoBehaviour {
         public CharacterManager characterManager;
         public bool enabledDamageColliderOnStartUp = false;
         Collider damageCollider;
 
+        [Header("PoiseDamage")]
+        public float poiseBreak;
+        public float offensivePoiseBonus;
+
+
+        [Header("Damage")]
         public float currentWeaponDamage;
         private void Awake() {
             damageCollider = GetComponent<Collider>();
@@ -44,7 +50,15 @@ namespace sg {
                     }
                 }
                 if (playerStats != null) {
-                    playerStats.TakeDamage(currentWeaponDamage);
+                    playerStats.poiseResetTimer = playerStats.totalPoiseResetTime;
+                    playerStats.totalPoiseDefense = playerStats.totalPoiseDefense - poiseBreak;
+
+                    if (playerStats.totalPoiseDefense > poiseBreak) { // 보스일경우 피격시 애니메이션 재생 X
+                        playerStats.TakeDamageNoAnimation(currentWeaponDamage);
+                        Debug.Log("Enemy Poise is currently " + playerStats.totalPoiseDefense);
+                    } else {
+                        playerStats.TakeDamage(currentWeaponDamage);
+                    }
                 }
             }
 
@@ -65,8 +79,12 @@ namespace sg {
                     }
                 }
                 if (enemyStats != null) {
-                    if (enemyStats.isBoss) { // 보스일경우 피격시 애니메이션 재생 X
+                    enemyStats.poiseResetTimer = enemyStats.totalPoiseResetTime;
+                    enemyStats.totalPoiseDefense = enemyStats.totalPoiseDefense - poiseBreak;
+
+                    if (enemyStats.totalPoiseDefense > poiseBreak) { // 보스일경우 피격시 애니메이션 재생 X
                         enemyStats.TakeDamageNoAnimation(currentWeaponDamage);
+                        Debug.Log("Enemy Poise is currently " + enemyStats.totalPoiseDefense);
                     } else {
                         enemyStats.TakeDamage(currentWeaponDamage);
                     }

--- a/Assets/Scripts/Items/Weapons/WeaponItem.cs
+++ b/Assets/Scripts/Items/Weapons/WeaponItem.cs
@@ -14,6 +14,10 @@ namespace sg {
         public float baseDamage = 25;
         public int criticalDamageMultiplier = 4;
 
+        [Header("Poise")]
+        public float poiseBreak;
+        public float offensivePoiseBonus;
+
         // 방어시 물리 피해 흡수량
         [Header("Absorption")]
         public float physicalDamageAbsorption;

--- a/Assets/Scripts/Managers/CharacterStats.cs
+++ b/Assets/Scripts/Managers/CharacterStats.cs
@@ -18,6 +18,15 @@ namespace sg {
 
         public int soulCount = 0;
 
+        // 강인도 : 슈퍼아머 유지를 위한 필요 수치
+        [Header("Poise")]
+        public float totalPoiseDefense; // 데미지 계산에서의 총 강인도
+        public float offensivePoiseBonus; // 공격모션중 강인도 보너스
+        public float armorPoiseBonus; // 갑옷을 입음으로써 얻는 강인도
+        public float totalPoiseResetTime = 15; // 강인도 초기화 시간
+        public float poiseResetTimer = 0; // 강인도 초기화 타이머
+        
+
         [Header("Armor Absorptions")]
         public float physicalDamageAbsorptionHead;
         public float physicalDamageAbsorptionBody;
@@ -25,6 +34,14 @@ namespace sg {
         public float physicalDamageAbsorptionHands;
 
         public bool isDead;
+
+        protected virtual void Update() {
+            HandlePoiseResetTimer();
+        }
+
+        private void Start() {
+            totalPoiseDefense = armorPoiseBonus;
+        }
 
         public virtual void TakeDamage(float physicalDamage, string damageAnimation = "Damage") {
             if (isDead) return;
@@ -39,6 +56,14 @@ namespace sg {
             if (currentHealth <= 0) {
                 currentHealth = 0;
                 isDead = true;
+            }
+        }
+
+        public virtual void HandlePoiseResetTimer() {
+            if (poiseResetTimer > 0) {
+                poiseResetTimer -= Time.deltaTime;
+            } else {
+                totalPoiseDefense = armorPoiseBonus;
             }
         }
     }

--- a/Assets/Scripts/Managers/WeaponSlotManager.cs
+++ b/Assets/Scripts/Managers/WeaponSlotManager.cs
@@ -91,11 +91,15 @@ namespace sg {
         private void LoadLeftWeaponDamageCollider() {
             leftHandDamageCollider = leftHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
             leftHandDamageCollider.currentWeaponDamage = playerInventory.leftWeapon.baseDamage;
+            // 왼쪽 무기의 DamageCollider에 현재 왼쪽 무기의 강인도 감쇄율을 전달
+            leftHandDamageCollider.poiseBreak = playerInventory.leftWeapon.poiseBreak;
         }
 
         private void LoadRightWeaponDamageCollider() {
             rightHandDamageCollider = rightHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
             rightHandDamageCollider.currentWeaponDamage = playerInventory.rightWeapon.baseDamage;
+            // 오른쪽 무기의 DamageCollider에 현재 오른쪽 무기의 강인도 감쇄율을 전달
+            rightHandDamageCollider.poiseBreak = playerInventory.rightWeapon.poiseBreak;
         }
 
         public void OpenDamageCollider() {


### PR DESCRIPTION
# CharacterStats
- 다크소울에서 강인도는 눈에보이지 않는 별개의 체력을 가지며 데미지를 입는경우 맞은 무기 혹은 기술에 따라 점차 깎여나감
- 강인도가 전부 깎이지 않는한 해당 오브젝트는 행동을 방해받지 않으며 슈퍼 아머를 갖는다
- 강인도 체력은 전부 깎여 나갔더라도 일정 시간 이상 피해를 입지 않으면 회복됨
- 총 강인도를 계산해 저장할 변수, 공격 모션중 강인도 보정치, 갑옷으로 인한 강인도, 강인도 초기화 시간, 강인도 초기화 시간을 계산할 타이머
- 강인도 초기화 타이머는 초기에 0으로 초기화, 피해를 받는다면 그 즉시 시간을 잰다

# DamageCollider
- 모든 무기가 공통으로 가지고 있을 타격판정을 위한 클래스
- 무기 마다 강인도 감쇄율이 다르므로 타격을 입힌 무기로부터 강인도 감쇄율을 받아올 변수
- 공격모션중 보정치를 받아올 변수
- 타격을 입힌 대상의 강인도를 검사하며 알맞은 피격 함수를 실행

# WeaponItem
- 강인도 감쇄율, 공격 모션중 보정치

# WeaponSlotManager
- 양손에 장착된 무기들을 불러오는 함수에서 강인도 감쇄율을 DamageCollider에 전달한다