### PR TITLE
피아식별

### DIFF
--- a/Assets/Data/Items/Consumables/Estus Flask.asset
+++ b/Assets/Data/Items/Consumables/Estus Flask.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d2aceb75383384469f1f52567ac7f04, type: 3}
   m_Name: Estus Flask
   m_EditorClassIdentifier: 
-  itemIcon: {fileID: 0}
+  itemIcon: {fileID: 21300000, guid: 51e90e2f352d93d49b72bebce22d5c10, type: 3}
   itemName: Estus Flask
   maxItemAmount: 10
   currentItemAmount: 10

--- a/Assets/Data/Items/Consumables/FireBomb.asset
+++ b/Assets/Data/Items/Consumables/FireBomb.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b394195bc432fc348b288095c5e4987d, type: 3}
   m_Name: FireBomb
   m_EditorClassIdentifier: 
-  itemIcon: {fileID: 0}
-  itemName: 
+  itemIcon: {fileID: 21300000, guid: 062eeb9d5e8ba8f45a9ddfea52518f82, type: 3}
+  itemName: FireBomb
   maxItemAmount: 20
   currentItemAmount: 20
   itemModel: {fileID: 7718585223797566845, guid: 9f84e2ee8daaabd45a1c0ac420a96b47, type: 3}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -377,6 +377,82 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 93841444}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &106287073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 106287074}
+  - component: {fileID: 106287076}
+  - component: {fileID: 106287075}
+  m_Layer: 5
+  m_Name: SpellIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &106287074
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106287073}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5249675476912954039}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -2.5, y: -0.0000095367}
+  m_SizeDelta: {x: 105, y: 130}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &106287075
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106287073}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &106287076
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106287073}
+  m_CullTransparentMesh: 1
 --- !u!1 &143688769
 GameObject:
   m_ObjectHideFlags: 0
@@ -2065,6 +2141,82 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 927066293}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &957038878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 957038879}
+  - component: {fileID: 957038881}
+  - component: {fileID: 957038880}
+  m_Layer: 5
+  m_Name: ConsumableIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &957038879
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 957038878}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5249675477421467389}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 110, y: 130}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &957038880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 957038878}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &957038881
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 957038878}
+  m_CullTransparentMesh: 1
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -12529,6 +12681,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   leftWeaponIcon: {fileID: 1796795120095012172}
   rightWeaponIcon: {fileID: 1796795120472280426}
+  currentSpellIcon: {fileID: 106287075}
+  currentConsumableIcon: {fileID: 957038880}
 --- !u!114 &2442384755271884258
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24396,7 +24550,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 106287074}
   m_Father: {fileID: 5249675476931356717}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -24496,7 +24651,7 @@ GameObject:
   - component: {fileID: 5249675477421467387}
   - component: {fileID: 5249675477421467386}
   m_Layer: 5
-  m_Name: QuickSlot
+  m_Name: ConsumableSlot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -24513,7 +24668,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 957038879}
   m_Father: {fileID: 5249675476931356717}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -25205,6 +25361,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d978634805ad16b43948ae384e6a93a4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamIDNumber: 0
   soulsAwardedOnDeath: 0
   healthLevel: 10
   maxHealth: 0
@@ -26084,6 +26241,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b3ed6b924acef144097847a59bee8a07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamIDNumber: 1
   soulsAwardedOnDeath: 0
   healthLevel: 20
   maxHealth: 0
@@ -29462,6 +29620,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b3ed6b924acef144097847a59bee8a07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  teamIDNumber: 0
   soulsAwardedOnDeath: 0
   healthLevel: 10
   maxHealth: 0

--- a/Assets/Scripts/AI/Manager/EnemyWeaponSlotManager.cs
+++ b/Assets/Scripts/AI/Manager/EnemyWeaponSlotManager.cs
@@ -43,12 +43,14 @@ namespace sg {
                 leftHandDamageCollider.characterManager = GetComponentInParent<CharacterManager>();
                 leftHandDamageCollider.physicalDamage = leftHandWeapon.physicalDamage;
                 leftHandDamageCollider.fireDamage = leftHandWeapon.fireDamage;
+                leftHandDamageCollider.teamIDNumber = enemyStatsManager.teamIDNumber;
                 enemyEffectsManager.leftWeaponFX = leftHandSlot.currentWeaponModel.GetComponentInChildren<WeaponFX>();
             } else {
                 rightHandDamageCollider = rightHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
                 rightHandDamageCollider.characterManager = GetComponentInParent<CharacterManager>();
                 rightHandDamageCollider.physicalDamage = rightHandWeapon.physicalDamage;
                 rightHandDamageCollider.fireDamage = rightHandWeapon.fireDamage;
+                rightHandDamageCollider.teamIDNumber = enemyStatsManager.teamIDNumber;
                 enemyEffectsManager.rightWeaponFX = rightHandSlot.currentWeaponModel.GetComponentInChildren<WeaponFX>();
             }
         }

--- a/Assets/Scripts/AI/States/IdleState.cs
+++ b/Assets/Scripts/AI/States/IdleState.cs
@@ -19,7 +19,7 @@ namespace sg {
                 CharacterStatsManager characterStats = colliders[i].transform.GetComponent<CharacterStatsManager>();
 
                 // 해당 오브젝트에 CharacterStats이 존재한다면
-                if (characterStats != null) {
+                if (characterStats != null && characterStats.teamIDNumber != enemyStats.teamIDNumber) {
                     Vector3 targetDirection = characterStats.transform.position - enemyManager.transform.position;
                     float viewableAngle = Vector3.Angle(targetDirection, enemyManager.transform.forward);
 

--- a/Assets/Scripts/BombDamageCollider.cs
+++ b/Assets/Scripts/BombDamageCollider.cs
@@ -25,8 +25,7 @@ namespace sg {
 
                 CharacterStatsManager character = collision.transform.GetComponent<CharacterStatsManager>();
 
-                if (character != null) {
-                    // 피아 식별 필요
+                if (character != null && character.teamIDNumber != teamIDNumber) {
                     character.TakeDamage(0, contactDamage);
                 }
                 Destroy(impactParticles, 5f);
@@ -38,7 +37,7 @@ namespace sg {
             Collider[] characters = Physics.OverlapSphere(transform.position, explosiveRadius);
             foreach (Collider character in characters) {
                 CharacterStatsManager characterStats = character.GetComponent<CharacterStatsManager>();
-                if (characterStats != null) {
+                if (characterStats != null && characterStats.teamIDNumber != teamIDNumber) {
                     characterStats.TakeDamage(0, fireExplosionDamage);
                 }
             }

--- a/Assets/Scripts/Common/CharacterStatsManager.cs
+++ b/Assets/Scripts/Common/CharacterStatsManager.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 namespace sg {
     public class CharacterStatsManager : MonoBehaviour {
+        [Header("Team I.D")]
+        public int teamIDNumber;
+        
         public int soulsAwardedOnDeath;
 
         public int healthLevel = 10;

--- a/Assets/Scripts/Items/Spells/ProjectileSpell.cs
+++ b/Assets/Scripts/Items/Spells/ProjectileSpell.cs
@@ -22,19 +22,22 @@ namespace sg {
             animatorHandler.PlayTargetAnimation(spellAnimation, true);
         }
 
-        public override void SuccessfullyCastSpell(PlayerAnimatorManager animatorHandler, PlayerStatsManager playerStats, CameraHandler cameraHandler, PlayerWeaponSlotManager weaponSlotManager) {
-            base.SuccessfullyCastSpell(animatorHandler, playerStats, cameraHandler, weaponSlotManager);
+        public override void SuccessfullyCastSpell(PlayerAnimatorManager animatorHandler, PlayerStatsManager playerStatsManager, CameraHandler cameraHandler, PlayerWeaponSlotManager weaponSlotManager) {
+            base.SuccessfullyCastSpell(animatorHandler, playerStatsManager, cameraHandler, weaponSlotManager);
             GameObject instantiatedSpellFX = Instantiate(spellCastFX, weaponSlotManager.rightHandSlot.transform.position, cameraHandler.cameraPivotTransform.rotation);
             rigidbody = instantiatedSpellFX.GetComponent<Rigidbody>();
             //spellDamageCollider = instantiatedSpellFX.GetComponent<SpellDamageCollider>();
-
+            SpellDamageCollider spellDamageCollider = instantiatedSpellFX.GetComponent<SpellDamageCollider>();
+            
+            spellDamageCollider.teamIDNumber = playerStatsManager.teamIDNumber; // 피아식별을 위한 팀ID 설정
+            
             if (cameraHandler.currentLockOnTarget != null) {
                 // 락온 상태라면 락온된 대상의 방향으로 투사체가 날아간다.
                 instantiatedSpellFX.transform.LookAt(cameraHandler.currentLockOnTarget.transform);
             } else {
                 // 투사체가 발사되는 높이는 카메라에 의해 제어된다.
                 // 락온 상태가 아닐경우 플레이어가 바라보는 방향으로 투사체가 나가게끔 한다.
-                instantiatedSpellFX.transform.rotation = Quaternion.Euler(cameraHandler.cameraPivotTransform.eulerAngles.x, playerStats.transform.eulerAngles.y, 0);
+                instantiatedSpellFX.transform.rotation = Quaternion.Euler(cameraHandler.cameraPivotTransform.eulerAngles.x, playerStatsManager.transform.eulerAngles.y, 0);
             }
 
             rigidbody.AddForce(instantiatedSpellFX.transform.forward * projectileForwardVelocity);

--- a/Assets/Scripts/Items/Spells/SpellDamageCollider.cs
+++ b/Assets/Scripts/Items/Spells/SpellDamageCollider.cs
@@ -31,11 +31,12 @@ namespace sg {
         private void OnCollisionEnter(Collision collision) {
             if (!hasCollided) {
                 spellTarget = collision.transform.GetComponent<CharacterStatsManager>();
-                if (spellTarget != null) {
+                if (spellTarget != null && spellTarget.teamIDNumber != teamIDNumber) {
                     spellTarget.TakeDamage(0, fireDamage);
                 }
                 hasCollided = true;
                 impactParticles = Instantiate(impactParticles, transform.position, Quaternion.FromToRotation(Vector3.up, impactNormal)); // Vector3.up 을 impactNoraml 에 대해 회전
+                
                 Destroy(projectileParticles);
                 Destroy(impactParticles, 2f);
                 Destroy(gameObject, 5f);

--- a/Assets/Scripts/Items/Weapons/DamageCollider.cs
+++ b/Assets/Scripts/Items/Weapons/DamageCollider.cs
@@ -10,6 +10,9 @@ namespace sg {
         //public WeaponFX weaponFX;
         protected Collider damageCollider;
 
+        [Header("Team I.D")]
+        public int teamIDNumber; // 피아식별에 사용할 ID
+
         [Header("PoiseDamage")]
         public float poiseBreak;
         public float offensivePoiseBonus;
@@ -41,6 +44,7 @@ namespace sg {
                 BlockingCollider shield = other.transform.GetComponentInChildren<BlockingCollider>();
 
                 if (enemyManager != null) {
+                    if (enemyStats.teamIDNumber == teamIDNumber) return; 
                     if (enemyManager.isParrying) {
                         characterManager.GetComponentInChildren<AnimatorManager>().PlayTargetAnimation("Parried", true);
                         return;
@@ -55,6 +59,8 @@ namespace sg {
                     }
                 }
                 if (enemyStats != null) {
+                    if (enemyStats.teamIDNumber == teamIDNumber) return;
+
                     enemyStats.poiseResetTimer = enemyStats.totalPoiseResetTime;
                     enemyStats.totalPoiseDefense = enemyStats.totalPoiseDefense - poiseBreak;
                     

--- a/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
@@ -108,6 +108,7 @@ namespace sg {
             damageCollider.fireExplosionDamage = fireBombItem.explosiveDamage;
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.forward * fireBombItem.forwardVelocity);
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.up * fireBombItem.upwardVelocity);
+            damageCollider.teamIDNumber = playerStatsManager.teamIDNumber; // 피아식별을 위한 팀ID 설정
             // LoadWeaponSlot(playerInventory.rightWeapon, false);
             
         }
@@ -118,7 +119,8 @@ namespace sg {
             leftHandDamageCollider = leftHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
             leftHandDamageCollider.physicalDamage = playerInventoryManager.leftWeapon.physicalDamage;
             leftHandDamageCollider.fireDamage = playerInventoryManager.leftWeapon.fireDamage;
-
+            leftHandDamageCollider.teamIDNumber = playerStatsManager.teamIDNumber;
+            
             // 왼쪽 무기의 DamageCollider에 현재 왼쪽 무기의 강인도 감쇄율을 전달
             leftHandDamageCollider.poiseBreak = playerInventoryManager.leftWeapon.poiseBreak;
             // 현재 왼쪽손에 들려있는 무기 모델의 자식에 있는 WeaponFX 스크립트 파일을 불러옴
@@ -129,6 +131,7 @@ namespace sg {
             rightHandDamageCollider = rightHandSlot.currentWeaponModel.GetComponentInChildren<DamageCollider>();
             rightHandDamageCollider.physicalDamage = playerInventoryManager.rightWeapon.physicalDamage;
             rightHandDamageCollider.fireDamage = playerInventoryManager.rightWeapon.fireDamage;
+            rightHandDamageCollider.teamIDNumber = playerStatsManager.teamIDNumber;
 
             // 오른쪽 무기의 DamageCollider에 현재 오른쪽 무기의 강인도 감쇄율을 전달
             rightHandDamageCollider.poiseBreak = playerInventoryManager.rightWeapon.poiseBreak;

--- a/Assets/Scripts/UI/QuickSlots.cs
+++ b/Assets/Scripts/UI/QuickSlots.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 namespace sg {
     public class QuickSlots : MonoBehaviour {
         public Image leftWeaponIcon, rightWeaponIcon;
+        public Image currentSpellIcon, currentConsumableIcon;
 
         public void UpdateWeaponQuickSlotsUI(bool isLeft, WeaponItem weapon) {
             if (isLeft == false) {
@@ -23,6 +24,26 @@ namespace sg {
                     leftWeaponIcon.sprite = null;
                     leftWeaponIcon.enabled = false;
                 }
+            }
+        }
+
+        public void UpdateCurrentSpellIcon(SpellItem spellItem) {
+            if (spellItem.itemIcon != null) {
+                currentSpellIcon.sprite = spellItem.itemIcon;
+                currentSpellIcon.enabled = true;
+            } else {
+                currentSpellIcon.sprite = null;
+                currentSpellIcon.enabled = false;
+            }
+        }
+
+        public void UpdateCurrentConsumableIcon(ConsumableItem consumableItem) {
+            if (consumableItem.itemIcon != null) {
+                currentConsumableIcon.sprite = consumableItem.itemIcon;
+                currentConsumableIcon.enabled = true;
+            } else {
+                currentConsumableIcon.sprite = null;
+                currentConsumableIcon.enabled = false;
             }
         }
     }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -7,6 +7,7 @@ namespace sg {
     public class UIManager : MonoBehaviour {
         public PlayerInventoryManager playerInventory;
         public EquipmentWindowUI equipmentWindowUI;
+        private QuickSlots quickSlots;
 
         [Header("UI Windows")]
         public GameObject hudWindow;
@@ -27,10 +28,13 @@ namespace sg {
         WeaponInventorySlot[] weaponInventorySlots; // 인벤토리 슬롯 배열
 
         private void Awake() {
+            quickSlots = GetComponentInChildren<QuickSlots>();
         }
         private void Start() {
             weaponInventorySlots = weaponInventorySlotsParent.GetComponentsInChildren<WeaponInventorySlot>();
             equipmentWindowUI.LoadWeaponOnEquipmentScreen(playerInventory);
+            quickSlots.UpdateCurrentSpellIcon(playerInventory.currentSpell);
+            quickSlots.UpdateCurrentConsumableIcon(playerInventory.currentConsumable);
         }
         public void UpdateUI() {
             #region Weapon Inventory Slots


### PR DESCRIPTION
# DamageCollider
- 피아 식별을 위한 변수 추가
- 해당 변수의 값이 다르면 적으로 인식되고 데미지를 입힐수 있다

# CharacterStatsManager
- 피아 식별을 위한 변수 추가

# ProjectileSpell
- 피아식별을 위해 투사체의 DamageCollider로 부터 teamID를 참조한다

# BombDamageCollider + SpellDamageCollider + IdleState
- teamID 를 이용한 피아식별

# PlayerWeaponSlotManager + EnemyWeaponSlotManager
- 무기의 DamageCollider를 참조할때 teamID 변수도 참조한다

# QuickSlots
- 소모품, 주문칸에 아이콘을 출력하기 위한 변수와 함수

# UIManager
- 소모품 칸과 주문 칸에 아이콘을 출력하기 위해 QuickSlots 스크립트를 참조하고 기능을 호출한다