### PR TITLE
보스

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid AI.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid AI.controller
@@ -1194,6 +1194,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: isDead
     m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: isGrabbed
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3113570552372975617}
   m_Solo: 0
@@ -1820,85 +1823,91 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInteracting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canDoCombo
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canRotate
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingRightHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingLeftHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInvulnerable
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isBlocking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isFiringSpell
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isRotatingWithRootMotion
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isPhaseShifting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: isGrabbed
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -2254,6 +2263,9 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: isGrabbed
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -8787761360574702309}
@@ -2796,7 +2808,7 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 2
+  - m_ConditionMode: 1
     m_ConditionEvent: isInvulnerable
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}

--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -1861,85 +1861,85 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInteracting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canDoCombo
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canRotate
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingRightHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingLeftHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInvulnerable
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isBlocking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isFiringSpell
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isRotatingWithRootMotion
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: doEmpty
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -3140,16 +3140,16 @@ AnimatorStateMachine:
     m_Position: {x: 580, y: -420, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4552435795597197025}
-    m_Position: {x: 370, y: 210, z: 0}
+    m_Position: {x: 360, y: 190, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6047846892116732301}
-    m_Position: {x: 370, y: 260, z: 0}
+    m_Position: {x: 360, y: 240, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8787761360574702309}
-    m_Position: {x: 220, y: 330, z: 0}
+    m_Position: {x: 210, y: 310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5493193844379995381}
-    m_Position: {x: 550, y: 330, z: 0}
+    m_Position: {x: 540, y: 310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1154965276067657945}
     m_Position: {x: 100, y: -310, z: 0}

--- a/Assets/Scripts/AI/Manager/BossManager.cs
+++ b/Assets/Scripts/AI/Manager/BossManager.cs
@@ -28,6 +28,7 @@ namespace sg {
         public void UpdateBossHealthBar(float currentHealth, float maxHealth) {
             bossHealthBar.SetBossCurrentHealth(currentHealth);
             if (currentHealth <= maxHealth / 2 && !bossCombatStanceState.hasPhaseShifted) {
+                if (enemyStats.isStuned) return;
                 //Debug.Log("2페이즈 진입");
                 bossCombatStanceState.hasPhaseShifted = true;
                 ShiftToSecondPhase();

--- a/Assets/Scripts/AI/Manager/EnemyManager.cs
+++ b/Assets/Scripts/AI/Manager/EnemyManager.cs
@@ -55,7 +55,7 @@ namespace sg {
             canRotate = enemyAnimatorManager.anim.GetBool("canRotate");
             isInvulnerable = enemyAnimatorManager.anim.GetBool("isInvulnerable");
             enemyAnimatorManager.anim.SetBool("isDead", enemyStatsManager.isDead);
-
+            enemyAnimatorManager.anim.SetBool("isGrabbed", isGrabbed);
         }
 
         private void LateUpdate() {

--- a/Assets/Scripts/AI/Manager/EnemyStatsManager.cs
+++ b/Assets/Scripts/AI/Manager/EnemyStatsManager.cs
@@ -36,6 +36,9 @@ namespace sg {
                 enemyHealthBar.SetHealth(currentHealth);
             else if (isBoss && bossManager != null)
                 bossManager.UpdateBossHealthBar(currentHealth, maxHealth);
+            if (isDead && !enemyManager.isGrabbed) {
+                HandleDeath("Dead");
+            }
         }
 
         public override void TakePoisonDamage(float damage) {
@@ -45,7 +48,7 @@ namespace sg {
             else if (isBoss && bossManager != null)
                 bossManager.UpdateBossHealthBar(currentHealth, maxHealth);
             
-            if (currentHealth <= 0) {
+            if (isDead && !enemyManager.isGrabbed) {
                 HandleDeath("PoisonedDeath");
             }
         }
@@ -59,7 +62,7 @@ namespace sg {
                 bossManager.UpdateBossHealthBar(currentHealth, maxHealth);
 
             enemyAnimatorManager.PlayTargetAnimation(damageAnimation, true);
-            if (isDead) {
+            if (isDead && !enemyManager.isGrabbed) {
                 HandleDeath("Dead");
             }
         }

--- a/Assets/Scripts/Common/CharacterAnimatorManager.cs
+++ b/Assets/Scripts/Common/CharacterAnimatorManager.cs
@@ -79,8 +79,8 @@ namespace sg {
         }
 
         public virtual void TakeCriticalDamageAnimationEvent() {
-            characterStatsManager.TakeDamageNoAnimation(characterManager.pendingCriticalDamage);
-            characterManager.pendingCriticalDamage = 0;
+            characterStatsManager.TakeDamageNoAnimation(characterManager.pendingCriticalDamage); // 잡기 대상에게 데미지
+            characterManager.pendingCriticalDamage = 0; // 잡기 데미지 초기화
         }
 
         // 보스 혹은 엘리트 몬스터의 강인도 초기화 이벤트
@@ -89,6 +89,12 @@ namespace sg {
             characterStatsManager.totalPoiseDefense = characterStatsManager.armorPoiseBonus;
             characterStatsManager.poiseResetTimer = 0;
         }
+
+        public virtual void ReleaseFromGrab() {
+            if (characterStatsManager.isDead) return;
+            characterManager.isGrabbed = false;
+        }
+
         #endregion
 
         // 무기의 HandIK 설정

--- a/Assets/Scripts/Common/CharacterManager.cs
+++ b/Assets/Scripts/Common/CharacterManager.cs
@@ -25,6 +25,7 @@ namespace sg {
         public bool canDoCombo;
         public bool isUsingRightHand;
         public bool isUsingLeftHand;
+        public bool isGrabbed;
 
         [Header("Movement Flags")]
         public bool isRotatingWithRootMotion;

--- a/Assets/Scripts/Common/ResetAnimatorBool.cs
+++ b/Assets/Scripts/Common/ResetAnimatorBool.cs
@@ -24,6 +24,7 @@ public class ResetAnimatorBool : StateMachineBehaviour {
 
     public string isRotatingWithRootMotion = "isRotatingWithRootMotion";
     public bool isRotatingWithRootMotionStatus = false;
+
     public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex) {
         animator.SetBool(isInteractingBool, isInteractingStatus);
         animator.SetBool(isFiringSpellBool, isFiringSpellStatus);

--- a/Assets/Scripts/Items/Weapons/DamageCollider.cs
+++ b/Assets/Scripts/Items/Weapons/DamageCollider.cs
@@ -64,7 +64,7 @@ namespace sg {
                     ChooseWhichDirectionDamageCameFrom(directionHitFrom);
                     enemyEffectsManager.PlayBloodSplatterFX(contactPoint);
                     if (enemyStats.isBoss) {
-                        if (enemyStats.totalPoiseDefense <= 0 && !enemyStats.isStuned) {
+                        if (enemyStats.totalPoiseDefense < 0 && !enemyStats.isStuned) {
                             enemyStats.isStuned = true;
                             enemyStats.transform.GetComponent<CharacterAnimatorManager>().PlayTargetAnimation("BreakGuard", true);
                         }

--- a/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
@@ -183,6 +183,7 @@ namespace sg {
                     // 애니메이션 재생
                     playerAnimatorManager.PlayTargetAnimation("Back Stab", true);
                     enemyCharacterManager.GetComponentInChildren<CharacterAnimatorManager>().PlayTargetAnimation("Back Stabbed", true);
+                    enemyCharacterManager.isGrabbed = true;
                 }
             } else if (Physics.Raycast(inputHandler.criticalAttackRayCastStartPoint.position, transform.TransformDirection(Vector3.forward), out hit, 0.7f, riposteLayer)) {
                 CharacterManager enemyCharacterManager = hit.transform.gameObject.GetComponentInParent<CharacterManager>();
@@ -203,6 +204,8 @@ namespace sg {
 
                     playerAnimatorManager.PlayTargetAnimation("Riposte", true);
                     enemyCharacterManager.GetComponentInChildren<CharacterAnimatorManager>().PlayTargetAnimation("Riposted", true);
+                    enemyCharacterManager.canBeRiposted = false;
+                    enemyCharacterManager.isGrabbed = true;
                 }
             }
         }


### PR DESCRIPTION
# CharacterManager
- 앞 잡기, 뒤 잡기 상태를 표시하기 위한 isGrabbed 변수

# EnemyManager
- Update 메서드에서 Enemy, Boss Animator 의 isGrabbed 매개변수를 CharacterManager 의 isGrabbed 변수로 제어

# PlayerCombatManager
- 앞 잡기와 뒤 잡기 시전시 Enemy 의 isGrabbed 를 true로  설정
- 앞 잡기를 시전하면 canBeRiposted 를 false로 만들어 패리 없이 계속 앞잡기가 되는것 방지

# CharacterAnimatorManager
- 애니메이션 이벤트로 앞 잡기, 뒤 잡기 애니메이션 중 데미지를 전달하는 프레임 뒤에 추가하여 isGrabbed를 false로 만들어 주기 위한 함수
- 만약 앞잡이나 뒤잡 공격으로 체력이 0이되어 isDead가 true가 되면 isGrabbed 를 초기화해주지 않는다.

# EnemyStatsManager
- 데미지를 받는 함수 내에서 사망을 처리할때, isDead 가 true고 isGrabbed 가 false라면 일반적인 공격으로 사망한 것이므로 기본 사망 모션 재생

# BossManager
- 페이즈 전환 함수를 호출하는 부분에서 만약 그로기 상태(isStuned 가 true)라면 페이즈 전환을 보류한다.
- 이후 공격을 다시 허용하면 그때 페이즈 전환