### PR TITLE
NPC 대화

### DIFF
--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_A.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_A.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: CommonDialog1_A
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isStart: 1
+  isEnd: 0
+  isQuest: 0
+  script: "\uB300\uD6541_A"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_B.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_B.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: CommonDialog1_B
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  isEnd: 0
+  script: "\uB300\uD6541_B"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_C.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_C.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: CommonDialog1_C
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  isEnd: 0
+  script: "\uB300\uD6541_C"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_D.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_D.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: CommonDialog1_D
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  isEnd: 0
+  script: "\uB300\uD6541_D"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_E.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Common1/CommonDialog1_E.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: CommonDialog1_E
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  isEnd: 1
+  script: "\uB300\uD6541_E"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_A.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_A.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: FirstEncounter_A
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  script: "\uCCAB \uC870\uC6B0 \uB300\uD654-A"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_B.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_B.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: FirstEncounter_B
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  script: "\uCCAB \uC870\uC6B0 \uB300\uD654-B"

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_C.asset
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/FirstEncounter/FirstEncounter_C.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f11b2c62f006c46a813e9eb304dbb3, type: 3}
+  m_Name: FirstEncounter_C
+  m_EditorClassIdentifier: 
+  questCode: 0
+  isQuest: 0
+  script: "\uCCAB \uC870\uC6B0 \uB300\uD654-C"

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1846,6 +1846,7 @@ MonoBehaviour:
   allowAIToPerformCombos: 0
   drawnWeapon: 0
   comboLikelyHood: 0
+  hadMetBefore: 0
   aggravationToEnemy: 0
   aggravationToPlayer: 0
 --- !u!114 &591270342
@@ -2305,6 +2306,83 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 709703606}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &734537353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 734537354}
+  - component: {fileID: 734537356}
+  - component: {fileID: 734537355}
+  m_Layer: 5
+  m_Name: DialogUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &734537354
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734537353}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1416483556}
+  m_Father: {fileID: 8201319160160450548}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -34.9015}
+  m_SizeDelta: {x: 0, y: 69.8029}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &734537355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734537353}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21568628, g: 0.21568628, b: 0.21568628, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &734537356
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 734537353}
+  m_CullTransparentMesh: 1
 --- !u!1 &741671801
 GameObject:
   m_ObjectHideFlags: 0
@@ -2738,86 +2816,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   poisonBuildUpAmount: 7
   charactersInsidePoisonSurface: []
---- !u!1 &880356954
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 880356955}
-  - component: {fileID: 880356957}
-  - component: {fileID: 880356956}
-  m_Layer: 5
-  m_Name: Conversation3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &880356955
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 880356954}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1118751045}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &880356956
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 880356954}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &880356957
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 880356954}
-  m_CullTransparentMesh: 1
 --- !u!1 &917399106
 GameObject:
   m_ObjectHideFlags: 0
@@ -3558,86 +3556,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   torsoModels: []
---- !u!1 &1030272462
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1030272463}
-  - component: {fileID: 1030272465}
-  - component: {fileID: 1030272464}
-  m_Layer: 5
-  m_Name: FirstEncounter
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1030272463
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1030272462}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1118751045}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1030272464
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1030272462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &1030272465
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1030272462}
-  m_CullTransparentMesh: 1
 --- !u!1 &1034866462
 GameObject:
   m_ObjectHideFlags: 0
@@ -4006,86 +3924,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1104706067}
   m_CullTransparentMesh: 1
---- !u!1 &1106534847
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1106534848}
-  - component: {fileID: 1106534850}
-  - component: {fileID: 1106534849}
-  m_Layer: 5
-  m_Name: Suggestion
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1106534848
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1106534847}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1118751045}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1106534849
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1106534847}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &1106534850
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1106534847}
-  m_CullTransparentMesh: 1
 --- !u!1 &1117275922
 GameObject:
   m_ObjectHideFlags: 0
@@ -4142,111 +3980,6 @@ MonoBehaviour:
     m_HintWeight: 1
     m_MaintainTargetPositionOffset: 0
     m_MaintainTargetRotationOffset: 0
---- !u!1 &1118751044
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1118751045}
-  - component: {fileID: 1118751048}
-  - component: {fileID: 1118751047}
-  - component: {fileID: 1118751046}
-  m_Layer: 5
-  m_Name: ConversationUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1118751045
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1118751044}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1030272463}
-  - {fileID: 1866886410}
-  - {fileID: 1835377519}
-  - {fileID: 880356955}
-  - {fileID: 1106534848}
-  m_Father: {fileID: 8201319160160450548}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1118751046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1118751044}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &1118751047
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1118751044}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &1118751048
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1118751044}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
 --- !u!1 &1122703630
 GameObject:
   m_ObjectHideFlags: 0
@@ -5357,6 +5090,86 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   npcCombatStanceState: {fileID: 2048813013}
+--- !u!1 &1416483555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1416483556}
+  - component: {fileID: 1416483558}
+  - component: {fileID: 1416483557}
+  m_Layer: 5
+  m_Name: DialogText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1416483556
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416483555}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 734537354}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1416483557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416483555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 25
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1416483558
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416483555}
+  m_CullTransparentMesh: 1
 --- !u!1 &1426039081
 GameObject:
   m_ObjectHideFlags: 0
@@ -6392,86 +6205,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1823593855}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1835377518
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1835377519}
-  - component: {fileID: 1835377521}
-  - component: {fileID: 1835377520}
-  m_Layer: 5
-  m_Name: Conversation2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1835377519
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835377518}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1118751045}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1835377520
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835377518}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &1835377521
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835377518}
-  m_CullTransparentMesh: 1
 --- !u!1 &1842569823
 GameObject:
   m_ObjectHideFlags: 0
@@ -6684,86 +6417,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1849011538}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1866886409
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1866886410}
-  - component: {fileID: 1866886412}
-  - component: {fileID: 1866886411}
-  m_Layer: 5
-  m_Name: Conversation1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1866886410
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866886409}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1118751045}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1866886411
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866886409}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &1866886412
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866886409}
-  m_CullTransparentMesh: 1
 --- !u!1 &1912551437
 GameObject:
   m_ObjectHideFlags: 0
@@ -27340,7 +26993,7 @@ GameObject:
   - component: {fileID: 4086121375643061411}
   - component: {fileID: 4086121375643061412}
   m_Layer: 9
-  m_Name: NPC
+  m_Name: Rogue NPC
   m_TagString: Character
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -27546,6 +27199,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   radius: 1
   interactableText: Talk
+  firstEncounterScripts:
+  - {fileID: 11400000, guid: e520b7e93e66ea34dada11d367382228, type: 2}
+  - {fileID: 11400000, guid: 4eb1898a655b7494883047ae603d7633, type: 2}
+  - {fileID: 11400000, guid: caddeadb11618d2459cd848b8fc69a66, type: 2}
+  dialog: []
 --- !u!1 &4090091869031233709
 GameObject:
   m_ObjectHideFlags: 0
@@ -29779,6 +29437,9 @@ MonoBehaviour:
   pendingCriticalDamage: 0
   interactableUIGameObject: {fileID: 8201319160594038124}
   itemInteractableGameObject: {fileID: 6383484620945623690}
+  dialogUI: {fileID: 734537353}
+  isInConversation: 0
+  currentDialog: []
   interactableUI: {fileID: 0}
 --- !u!114 &6353349341563976085
 MonoBehaviour:
@@ -30525,6 +30186,7 @@ MonoBehaviour:
   interactableText: {fileID: 8201319160449250047}
   itemText: {fileID: 6383484621615713582}
   itemImage: {fileID: 6383484621269160271}
+  dialogText: {fileID: 1416483557}
 --- !u!1 &6591371426602266572
 GameObject:
   m_ObjectHideFlags: 0
@@ -33300,7 +32962,7 @@ RectTransform:
   m_Children:
   - {fileID: 8201319160594038115}
   - {fileID: 6383484620945623691}
-  - {fileID: 1118751045}
+  - {fileID: 734537354}
   m_Father: {fileID: 485915058436078673}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/AI/Enemy/BossFXTransform.cs
+++ b/Assets/Scripts/AI/Enemy/BossFXTransform.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 // 보스전 2페이즈 시작시 보스의 무기가 인챈트 됨
-// 검날 부분에 인챈트 시키기위해 해당 Transform을 위한 빈 스크립트
+// 검날 부분에 인챈트 시키기위해 해당 Transform을 참조하기 위한 빈 스크립트
 public class BossFXTransform : MonoBehaviour{
 
 }

--- a/Assets/Scripts/AI/Enemy/States/CombatStanceState.cs
+++ b/Assets/Scripts/AI/Enemy/States/CombatStanceState.cs
@@ -74,7 +74,9 @@ namespace SoulsLike {
         protected void WalkAroundTarget(EnemyAnimatorManager enemyAnimatorManager) {
             // 앞으로 이동하는 모션만 사용하기 위함
             // 뒷걸음질을 구현하고 싶다면 verticalMovementValue 변수값 범위에 음수를 포함시키면 됨
-            verticalMovementValue = 0.5f;
+            verticalMovementValue = Random.Range(-1f, 1f);
+            if (verticalMovementValue < 0f) verticalMovementValue = 0f;
+            else verticalMovementValue = 0.5f;
 
             horizontalMovementValue = Random.Range(-1, 1);
             if (horizontalMovementValue <= 1 && horizontalMovementValue >= 0) {

--- a/Assets/Scripts/AI/NPC/NPCInteraction.cs
+++ b/Assets/Scripts/AI/NPC/NPCInteraction.cs
@@ -4,20 +4,32 @@ using UnityEngine;
 
 namespace SoulsLike {
     public class NPCInteraction : Interactable {
+        //QuestManager questManager
         NPCManager npcManager;
+        public NPCScript[] firstEncounterScripts;
+        public NPCScript[] dialog;
+        // public NPCScript[] suggestionDialog;
+        private bool readyForSuggestion = false;
+
         public override void Interact(PlayerManager playerManager) {
             base.Interact(playerManager);
-            Conversation(playerManager);
+            StartConverstation(playerManager);
         }
 
-        private void Conversation(PlayerManager playerManager) {
-            Debug.Log("NPC와 대화");
-            if (!npcManager.hadMetBefore) {
-                npcManager.hadMetBefore = true;
-                // 첫 조우시 다이얼로그 출력
+        private void StartConverstation(PlayerManager playerManager) {
+            Debug.Log("NPC와 대화 시작");
+            playerManager.isInConversation = true;
+
+            if (npcManager.interactCount == 0) {
+                // 첫 조우시 출력할 다이얼로그 전달
+                playerManager.currentDialog = firstEncounterScripts;
             } else {
-                // 평소 다이얼로그 출력
-                // 퀘스트가 있다면 퀘스트 제안
+                if (readyForSuggestion) {
+                    // 퀘스트가 있다면 퀘스트 다이얼로그 전달
+                    //playerManager.currentDialog = suggestionDialog;
+                }
+                // 평소 다이얼로그 전달
+                playerManager.currentDialog = dialog;
             }
         }
     }

--- a/Assets/Scripts/AI/NPC/NPCManager.cs
+++ b/Assets/Scripts/AI/NPC/NPCManager.cs
@@ -35,7 +35,7 @@ namespace SoulsLike {
         public bool drawnWeapon;
         public float comboLikelyHood;
 
-        public bool hadMetBefore = false;
+        public int interactCount = 0;
         public float aggravationToEnemy;
         public float aggravationToPlayer;
 

--- a/Assets/Scripts/AI/NPC/NPCScript.cs
+++ b/Assets/Scripts/AI/NPC/NPCScript.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+namespace SoulsLike {
+    [CreateAssetMenu(menuName = "AI/NPC Actions/NPC Script")]
+    public class NPCScript : ScriptableObject {
+        public int questCode;
+        public bool isStart;
+        public bool isEnd;
+        public bool isQuest;
+        public string script;
+    }
+}

--- a/Assets/Scripts/UI/InteractableUI.cs
+++ b/Assets/Scripts/UI/InteractableUI.cs
@@ -8,5 +8,6 @@ namespace SoulsLike {
         public Text interactableText;
         public Text itemText;
         public RawImage itemImage;
+        public Text dialogText;
     }
 }


### PR DESCRIPTION
# CombatStanceState
- Enemy가 Player한테 다가오지 않고 옆으로 걷는 상황을 만들기 위해 verticalMovementValue 값 수정

# NPCScript
- NPC 의 대사를 ScriptableObject로 만들기 위함
- 출력할 대사, 대화의 시작부분인지 혹은 끝부분인지, 현재 대화가 퀘스트로 이어질지 등의 정보를 가질 것

# PlayerManager
- NPC의 대사를 출력할 dialogUI
- NPC와 대화를 할때 카메라가 약간 줌 되는데 현재 상황이 대화중인지를 나타내기 위한 isInConversation
- 현재 출력할 NPC의 대화를 전달받기 위한 currentDialog

# NPCInteraction
- 모든 NPC들이 갖고있는 클래스
- Interactable 클래스를 상속받아 해당 NPC의 상호작용을 처리
- 상황에 맞는(첫 조우 혹은 퀘스트 제안) 대사 집을 PlayerManager 의 currentDialog 로 전달
- 대사집을 일일이 분리해서 만들어놓고 Player에게 전달할지 생각...