### PR TITLE
NPC 대화

### DIFF
--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
@@ -29463,7 +29463,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   teamIDNumber: 2
   soulsAwardedOnDeath: 0
-  healthLevel: 10
+  healthLevel: 999
   maxHealth: 0
   currentHealth: 0
   staminaLevel: 1000

--- a/Assets/Scripts/AI/NPC/NPCInteraction.cs
+++ b/Assets/Scripts/AI/NPC/NPCInteraction.cs
@@ -51,7 +51,7 @@ namespace SoulsLike {
         private void StartConverstation(PlayerManager playerManager) {
             Debug.Log("NPC와 대화 시작");
             playerManager.isInConversation = true;
-
+            
             // 첫 조우시 출력할 다이얼로그 전달
             if (npcManager.interactCount == 0) {
                 CopyScript(startIndex[0]);

--- a/Assets/Scripts/Player/CameraHandler.cs
+++ b/Assets/Scripts/Player/CameraHandler.cs
@@ -7,14 +7,16 @@ namespace SoulsLike {
 
         // 카메라가 포착할 타겟의 위치
         public Transform targetTransform;
-        // 카메라의 위치
+        // 카메라의 위치(중심 기준)
         public Transform cameraTransform;
-        // 카메라의 회전 중심 위치
+        // 카메라를 움직일때 사용할 깡통 변수
+        private Vector3 cameraTransformPosition;
+        // 카메라의 중심 위치
         public Transform cameraPivotTransform;
+        
         public LayerMask obstacleLayer; // 플레이어와 카메라 사이에 오브젝트가 존재할 경우 카메라를 플레이어에게 가깝게 밀착시키기 위해 충돌 체크를 하고 싶은 레이어
 
         private Transform myTransform; // CameraHolder의 Transform (= Player의 Transform)
-        private Vector3 cameraTransformPosition;
         //private Vector3 cameraFollowVelocity = Vector3.zero;
 
         public static CameraHandler singleton;
@@ -24,7 +26,7 @@ namespace SoulsLike {
         public float pivotSpeed = 0.03f;
 
         private float targetPosition;
-        private float defaultPosition;
+        private float defaultPosition; // 평소 카메라의 z좌표를 저장할 변수
 
         // Euler Angle을 사용하기 위한 변수
         private float lookAngle;
@@ -66,6 +68,7 @@ namespace SoulsLike {
             Vector3 targetPosition = Vector3.Lerp(myTransform.position, targetTransform.position, delta / followSpeed);
             myTransform.position = targetPosition;
 
+            ZoomForInteraction(delta);
             HandleCameraCollision(delta);
 
             //Debug.Log("플레이어 Position : " + targetTransform.position);
@@ -176,7 +179,7 @@ namespace SoulsLike {
                         Vector3 startPosition = targetTransform.GetComponentInChildren<LockOnTransform>().transform.position;
                         Vector3 endPosition = character.GetComponentInChildren<LockOnTransform>().transform.position;
                         Vector3 direction = endPosition - startPosition;
-                        
+
                         if (Physics.Linecast(startPosition, endPosition, out hit, obstacleLayer)) return;
                         availableTargets.Add(character);
                     }
@@ -231,6 +234,18 @@ namespace SoulsLike {
                 cameraPivotTransform.transform.localPosition = Vector3.SmoothDamp(cameraPivotTransform.transform.localPosition, newLockedPosition, ref velocity, Time.deltaTime);
             } else {
                 cameraPivotTransform.transform.localPosition = Vector3.SmoothDamp(cameraPivotTransform.transform.localPosition, newUnlockedPosition, ref velocity, Time.deltaTime);
+            }
+        }
+
+        public void ZoomForInteraction(float delta) {
+            if (playerManager.isInConversation) {
+                //Debug.Log("줌 인");
+                cameraTransformPosition.z = Mathf.Lerp(cameraTransform.localPosition.z, cameraTransform.localPosition.z + 5, delta);
+                cameraTransform.localPosition = cameraTransformPosition;
+            } else {
+                //Debug.Log("줌 아웃");
+                cameraTransformPosition.z = Mathf.Lerp(cameraTransform.localPosition.z, defaultPosition, delta);
+                cameraTransform.localPosition = cameraTransformPosition;
             }
         }
     }

--- a/Assets/Scripts/Player/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerManager.cs
@@ -11,8 +11,8 @@ namespace SoulsLike {
     public class PlayerManager : CharacterManager {
         InputHandler inputHandler;
         Animator anim;
-        public GameObject interactableUIGameObject; // 상호작용 메세지 (문 열기, 레버 내리기 등)
-        public GameObject itemInteractableGameObject; // 아이템 획득 메세지
+        public GameObject interactableUIGameObject; // 상호작용 메세지 (문 열기, 레버 내리기 등) : InteractionPopUp
+        public GameObject itemInteractableGameObject; // 아이템 획득 메세지 : ItemPopup
         public GameObject dialogUI; // NPC의 대사를 출력할 창
 
         // 다크소울 시리즈에서는 대화 도중 행동이 가능하므로 isInteracting 과 분리
@@ -99,7 +99,6 @@ namespace SoulsLike {
             inputHandler.d_Pad_Down = false;
             inputHandler.d_Pad_Left = false;
             inputHandler.d_Pad_Right = false;
-            if (inputHandler.a_Input) Debug.Log("엔터 버튼 초기화");
             inputHandler.a_Input = false;
             inputHandler.jump_Input = false;
             inputHandler.inventory_Input = false;


### PR DESCRIPTION
NPC 와 대화할때 카메라가 조금 가까이 감
대화가 끝나면 원상복구

# 해결 필요
- 대화 도중 플레이어가 거리를 벗어나면 대화 강제 종료되게 만들기
- NPC에게 뒤에서 치명적 일격시 xz좌표가 요동치는 점
- NPC가 추적상태에 돌입했을 때, 현재 추적대상이 아닌 다른 대상에게 피해를 입는다면 타겟 재설정 타이머 값을 크게 줄여 목표를 다시 설정할 수 있도록 하기
- NPC와 Enemy가 서로 밀리는 문제 (플레이어는 NPC와 Enemy를 밀지 못하지만 반대는 가능, NavMesh 문제 같기도 함)
- 공격 피해가 간헐적으로 두번씩 발생
- 아이템을 줍고나서 캐릭터가 줍는 동작을 취하는 동안은 상호작용 버튼으로 popup을 닫지 못함, 애니메이션이 실행되는 동안 isInteracting 이 true가 되고 isInteracting 이 true면 popup을 열거나 닫는 함수내에 진입불가
- 플레이어가 점프도중 Enemy나 NPC와 부딪히면 플레이어의 진행방향으로 밀리는 문제