### PR TITLE
Fix

### DIFF
--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
@@ -1834,7 +1834,7 @@ MonoBehaviour:
   npcRigidbody: {fileID: 0}
   navMeshAgent: {fileID: 0}
   targets: []
-  currentTarget: {fileID: 9058321785823695558}
+  currentTarget: {fileID: 0}
   rotationSpeed: 15
   maximumAggroRadius: 1.5
   attackDistance: 1.5

--- a/Assets/Scripts/AI/NPC/NPCManager.cs
+++ b/Assets/Scripts/AI/NPC/NPCManager.cs
@@ -81,7 +81,7 @@ namespace SoulsLike {
 
         private void HandleChangeTargetTimer() {
             if (changeTargetTimer <= 0) {
-                currentTarget = null;
+                //currentTarget = null;
                 changeTargetTimer = 0;
             } else {
                 //Debug.Log(changeTargetTimer);

--- a/Assets/Scripts/AI/NPC/States/NPCAttackState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCAttackState.cs
@@ -18,7 +18,7 @@ namespace SoulsLike {
 
             if (npcManager.changeTargetTimer <= 0 || npcManager.currentTarget.isDead) {
                 Debug.Log("Å¸°Ù Àç¼³Á¤");
-                //return npcSelectTargetState;
+                npcManager.currentTarget = null;
                 return npcIdleState;
             }
 

--- a/Assets/Scripts/AI/NPC/States/NPCCombatStanceState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCCombatStanceState.cs
@@ -29,7 +29,7 @@ namespace SoulsLike {
 
             if (npcManager.changeTargetTimer <= 0 || npcManager.currentTarget.isDead) {
                 Debug.Log("Å¸°Ù Àç¼³Á¤");
-                //return npcSelectTargetState;
+                npcManager.currentTarget = null;
                 return npcIdleState;
             }
             
@@ -95,14 +95,17 @@ namespace SoulsLike {
         }
 
         protected void WalkAroundTarget(NPCAnimatorManager npcAnimatorManager) {
-            verticalMovementValue = 0.5f;
+            //verticalMovementValue = 0.5f;
+
+            verticalMovementValue = Random.Range(-1, 1);
+            if (verticalMovementValue < 0) verticalMovementValue = 0f;
+            else verticalMovementValue = 0.5f;
 
             horizontalMovementValue = Random.Range(-1, 1);
-            if (horizontalMovementValue <= 1 && horizontalMovementValue >= 0) {
+            if (horizontalMovementValue >= 0)
                 horizontalMovementValue = 0.5f;
-            } else if (horizontalMovementValue >= -1 && horizontalMovementValue < 0) {
+            else
                 horizontalMovementValue = -0.5f;
-            }
         }
     }
 }

--- a/Assets/Scripts/AI/NPC/States/NPCIdleState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCIdleState.cs
@@ -10,6 +10,7 @@ namespace SoulsLike {
         int teamCode;
 
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
+            if (npcManager.targets.Count > 0) npcManager.targets.Clear();
             colliders = Physics.OverlapSphere(npcManager.transform.position, npcManager.detectionRadius, npcManager.hostileLayer);
             npcAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
             npcAnimatorManager.anim.SetFloat("Horizontal", 0, 0.1f, Time.deltaTime);

--- a/Assets/Scripts/AI/NPC/States/NPCPursueTargetState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCPursueTargetState.cs
@@ -15,11 +15,12 @@ namespace SoulsLike {
 
             if (npcManager.changeTargetTimer <= 0 || npcManager.currentTarget.isDead) {
                 Debug.Log("Å¸°Ù Àç¼³Á¤");
-                //return npcSelectTargetState;
+                npcManager.currentTarget = null;
                 return npcIdleState;
             }
 
             HandleRotateTowardsTarget(npcManager);
+            
             float distance = Vector3.Distance(npcManager.transform.position, npcManager.currentTarget.transform.position);
             if (distance <= npcManager.maximumAggroRadius) return npcCombatStanceState;
             else {

--- a/Assets/Scripts/AI/NPC/States/NPCSelectTargetState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCSelectTargetState.cs
@@ -9,6 +9,8 @@ namespace SoulsLike {
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
 
             if (npcManager.currentTarget == null) {
+                if (npcManager.targets.Count <= 0) return npcIdleState;
+
                 // 현재 주변 적대 관계 오브젝트들과의 거리를 구함
                 // 최소 거리에 있는 오브젝트를 목표로 설정
                 float shortestPath = Mathf.Infinity;
@@ -26,18 +28,15 @@ namespace SoulsLike {
                 }
             }
             if (npcManager.currentTarget != null) {
-                if (npcManager.currentTarget.isDead) {
+                if (!npcManager.currentTarget.isDead) {
+                    if (npcManager.changeTargetTimer <= 0) npcManager.changeTargetTimer = npcManager.changeTargetTime;
+                    return npcPursueTargetState;
+                } else {
                     npcManager.targets.Remove(npcManager.currentTarget);
                     npcManager.currentTarget = null;
-                    return npcIdleState;
                 }
-                
-                if (npcManager.changeTargetTimer <= 0)
-                    npcManager.changeTargetTimer = npcManager.changeTargetTime;
-                return npcPursueTargetState;
-            } else {
-                return npcIdleState;
             }
+            return npcIdleState;
         }
     }
 }


### PR DESCRIPTION
- 목표 재설정 타이머를 관리하며 타이머 값이 0 아래로 떨어지면 타겟을 null로 만드는 부분과 타이머가 0 아래로 떨어지면 상태를 전이하여 다시 목표를 탐색하는 부분이 분리되어 있었는데 아마 이때문에 버그가 난듯?(확실하지 않음)
- Idle, Select, Rotate 이외의 상태에서 타이머가 0이되면 바로 타겟이 null이 되어 가장 가까운 적대 상태의 오브젝트를 공격 혹은 추격하도록 수정
- 다른 상태에서 타이머가 0이 되거나 대상이 사망하여 idle 상태로 돌아오는 경우 똑같은 오브젝트를 targets에 여러번 등록하지 않도록 idle 상태에서 targets 를 한번 비운뒤 주변 오브젝트를 탐색