### PR TITLE
Fix

### DIFF
--- a/Assets/Scripts/AI/NPC/NPCManager.cs
+++ b/Assets/Scripts/AI/NPC/NPCManager.cs
@@ -68,6 +68,7 @@ namespace SoulsLike {
             isInvulnerable = npcAnimatorManager.anim.GetBool("isInvulnerable");
             npcAnimatorManager.anim.SetBool("isDead", npcStatsManager.isDead);
             npcAnimatorManager.anim.SetBool("isGrabbed", isGrabbed);
+            if (aggravationToPlayer >= 30 && canTalk) canTalk = false;
         }
 
         private void LateUpdate() {

--- a/Assets/Scripts/Items/Weapons/DamageCollider.cs
+++ b/Assets/Scripts/Items/Weapons/DamageCollider.cs
@@ -86,7 +86,7 @@ namespace SoulsLike {
                         }
                         if (npcManager.currentTarget != characterManager.transform.GetComponent<CharacterStatsManager>()) {
                             Debug.Log("타겟 설정 시간 감소");
-                            npcManager.changeTargetTimer -= (npcManager.changeTargetTime / 2.5f);
+                            npcManager.changeTargetTimer -= (npcManager.changeTargetTime / 2f);
                         }
                     }
                     enemyStats.totalPoiseDefense -= poiseBreak;


### PR DESCRIPTION
- 아이템을 줍고나서 화면에 아이템을 획득했다는 팝업창이 떠있는 경우 다른 오브젝트와의 상호작용 메세지가 나타나지 않도록 함
- 상호작용 버튼을 한번 더 누르면 아이템 획득 팝업창이 닫히며 다른 오브젝트들과의 상호작용 메세지가 나타난다