### PR TITLE
플레이어 UI

### DIFF
--- a/Assets/Data/Items/Spells/Heal Player.asset
+++ b/Assets/Data/Items/Spells/Heal Player.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afd18205250070641a96edde237df59a, type: 3}
   m_Name: Heal Player
   m_EditorClassIdentifier: 
-  itemIcon: {fileID: 0}
+  itemIcon: {fileID: 21300000, guid: 152f37433d7b19e4b8390fea388d2996, type: 3}
   itemName: Heal Player
   spellWarmUpFX: {fileID: 32974116992910233, guid: 7ca33c04d7e2577459b0a38cb5b7498d, type: 3}
   spellCastFX: {fileID: 2970547096073538130, guid: 70e54888e8ff28141ab85c8b73dda015, type: 3}

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
@@ -2003,6 +2003,196 @@ Transform:
   m_Father: {fileID: 2085477301}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &396976886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 396976887}
+  - component: {fileID: 396976891}
+  - component: {fileID: 396976890}
+  - component: {fileID: 396976889}
+  - component: {fileID: 396976888}
+  m_Layer: 5
+  m_Name: Right Hand Slot3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &396976887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396976886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2013356127}
+  m_Father: {fileID: 2974136225425912081}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 70, y: -108.97835}
+  m_SizeDelta: {x: 20, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &396976888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396976886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4262ff7b6163ded45828788d3a999ed9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  icon: {fileID: 815153122}
+  rightHandSlot1: 0
+  rightHandSlot2: 0
+  rightHandSlot3: 1
+  leftHandSlot1: 0
+  leftHandSlot2: 0
+  leftHandSlot3: 0
+--- !u!114 &396976889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396976886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 0.5686275, g: 0.015686275, b: 0.015686275, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 396976890}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8201319159029467312}
+        m_TargetAssemblyTypeName: sg.EquipmentWindowUI, Assembly-CSharp
+        m_MethodName: SelectRightHandSlot2
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 8201319160069572049}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 8201319160132821706}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 396976888}
+        m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
+        m_MethodName: SelectThisSlot
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &396976890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396976886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.49019608, g: 0.49019608, b: 0.49019608, a: 0.5882353}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &396976891
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396976886}
+  m_CullTransparentMesh: 1
 --- !u!1 &397561947
 GameObject:
   m_ObjectHideFlags: 0
@@ -4038,6 +4228,82 @@ Transform:
   m_Father: {fileID: 345117978}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &815153120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 815153121}
+  - component: {fileID: 815153123}
+  - component: {fileID: 815153122}
+  m_Layer: 5
+  m_Name: Item Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &815153121
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 815153120}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2013356127}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 16, y: 105}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &815153122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 815153120}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &815153123
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 815153120}
+  m_CullTransparentMesh: 1
 --- !u!1 &832777083
 GameObject:
   m_ObjectHideFlags: 0
@@ -5314,6 +5580,82 @@ Transform:
   m_Father: {fileID: 1212867232}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &988694074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 988694075}
+  - component: {fileID: 988694077}
+  - component: {fileID: 988694076}
+  m_Layer: 5
+  m_Name: Item Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &988694075
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988694074}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1762708211}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 16, y: 105}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &988694076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988694074}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &988694077
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988694074}
+  m_CullTransparentMesh: 1
 --- !u!1 &990568287
 GameObject:
   m_ObjectHideFlags: 0
@@ -7305,6 +7647,196 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1348730536}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1356991351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1356991352}
+  - component: {fileID: 1356991356}
+  - component: {fileID: 1356991355}
+  - component: {fileID: 1356991354}
+  - component: {fileID: 1356991353}
+  m_Layer: 5
+  m_Name: Left Hand Slot3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1356991352
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356991351}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1762708211}
+  m_Father: {fileID: 2974136225425912081}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 70, y: -228.97835}
+  m_SizeDelta: {x: 20, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1356991353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356991351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4262ff7b6163ded45828788d3a999ed9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  icon: {fileID: 988694076}
+  rightHandSlot1: 0
+  rightHandSlot2: 0
+  rightHandSlot3: 0
+  leftHandSlot1: 0
+  leftHandSlot2: 0
+  leftHandSlot3: 1
+--- !u!114 &1356991354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356991351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0, g: 0, b: 0, a: 1}
+    m_HighlightedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1356991355}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8201319159029467312}
+        m_TargetAssemblyTypeName: sg.EquipmentWindowUI, Assembly-CSharp
+        m_MethodName: SelectLeftHandSlot2
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 8201319160069572049}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 8201319160132821706}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1356991353}
+        m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
+        m_MethodName: SelectThisSlot
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1356991355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356991351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.49019608, g: 0.49019608, b: 0.49019608, a: 0.5882353}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1356991356
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1356991351}
+  m_CullTransparentMesh: 1
 --- !u!1 &1376252016
 GameObject:
   m_ObjectHideFlags: 0
@@ -9456,6 +9988,83 @@ Transform:
   m_Father: {fileID: 3951029161758272182}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1762708210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1762708211}
+  - component: {fileID: 1762708213}
+  - component: {fileID: 1762708212}
+  m_Layer: 5
+  m_Name: Right Hand Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1762708211
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762708210}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 988694075}
+  m_Father: {fileID: 1356991352}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1762708212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762708210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21568628, g: 0.21568628, b: 0.21568628, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0db2ec9010562f04db803a5e18b736d8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1762708213
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1762708210}
+  m_CullTransparentMesh: 1
 --- !u!1 &1790023397
 GameObject:
   m_ObjectHideFlags: 0
@@ -10432,7 +11041,15 @@ MonoBehaviour:
   m_RigLayers:
   - m_Rig: {fileID: 472035657}
     m_Active: 1
-  m_Effectors: []
+  m_Effectors:
+  - m_Transform: {fileID: 406119382}
+    m_Style:
+      shape: {fileID: 4300000, guid: c6793350c150f456688e39a81f97364a, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 0.1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
 --- !u!114 &1920339678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11039,6 +11656,83 @@ Transform:
   m_Father: {fileID: 1322492954}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2013356126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2013356127}
+  - component: {fileID: 2013356129}
+  - component: {fileID: 2013356128}
+  m_Layer: 5
+  m_Name: Right Hand Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2013356127
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013356126}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 815153121}
+  m_Father: {fileID: 396976887}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2013356128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013356126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21568628, g: 0.21568628, b: 0.21568628, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1fdd7a665bb1ad7459b5ad278ce563c6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2013356129
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013356126}
+  m_CullTransparentMesh: 1
 --- !u!1 &2027919305
 GameObject:
   m_ObjectHideFlags: 0
@@ -18511,8 +19205,10 @@ MonoBehaviour:
   weaponInventoryWindow: {fileID: 8201319160069572049}
   rightHandSlot1Selected: 0
   rightHandSlot2Selected: 0
+  rightHandSlot3Selected: 0
   leftHandSlot1Selected: 0
   leftHandSlot2Selected: 0
+  leftHandSlot3Selected: 0
   weaponInventorySlotPrefab: {fileID: 8201319160697999624}
   weaponInventorySlotsParent: {fileID: 8201319160572957559}
 --- !u!222 &1796795120095012171
@@ -22381,7 +23077,7 @@ MonoBehaviour:
   m_CellSize: {x: 20, y: 120}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 1
-  m_ConstraintCount: 2
+  m_ConstraintCount: 3
 --- !u!224 &2974136225425912081
 RectTransform:
   m_ObjectHideFlags: 0
@@ -22396,8 +23092,10 @@ RectTransform:
   m_Children:
   - {fileID: 8201319160437592437}
   - {fileID: 8201319159052718491}
+  - {fileID: 396976887}
   - {fileID: 8201319158972659116}
   - {fileID: 8201319159962625308}
+  - {fileID: 1356991352}
   m_Father: {fileID: 8201319158695148301}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -36973,8 +37671,10 @@ MonoBehaviour:
   icon: {fileID: 2974136225795343357}
   rightHandSlot1: 0
   rightHandSlot2: 0
+  rightHandSlot3: 0
   leftHandSlot1: 1
   leftHandSlot2: 0
+  leftHandSlot3: 0
 --- !u!222 &8201319158972659105
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -37119,11 +37819,11 @@ RectTransform:
   m_Children:
   - {fileID: 2974136226642121265}
   m_Father: {fileID: 2974136225425912081}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 40, y: -228.97835}
+  m_AnchoredPosition: {x: 30, y: -228.97835}
   m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8201319158972659117
@@ -37160,13 +37860,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rightHandSlot1: 0
   rightHandSlot2: 0
+  rightHandSlot3: 0
   leftHandSlot1: 0
   leftHandSlot2: 0
+  leftHandSlot3: 0
   handEquipmentSlotUI:
   - {fileID: 8201319158972659104}
   - {fileID: 8201319159962625296}
+  - {fileID: 1356991353}
   - {fileID: 8201319160437592393}
   - {fileID: 8201319159052718495}
+  - {fileID: 396976888}
 --- !u!224 &8201319159029467313
 RectTransform:
   m_ObjectHideFlags: 0
@@ -37373,7 +38077,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 60, y: -108.97835}
+  m_AnchoredPosition: {x: 50, y: -108.97835}
   m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8201319159052718495
@@ -37391,8 +38095,10 @@ MonoBehaviour:
   icon: {fileID: 2974136225133429406}
   rightHandSlot1: 0
   rightHandSlot2: 1
+  rightHandSlot3: 0
   leftHandSlot1: 0
   leftHandSlot2: 0
+  leftHandSlot3: 0
 --- !u!222 &8201319159144059964
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -37622,7 +38328,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &8201319159962625296
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -37638,8 +38344,10 @@ MonoBehaviour:
   icon: {fileID: 2974136224873481283}
   rightHandSlot1: 0
   rightHandSlot2: 0
+  rightHandSlot3: 0
   leftHandSlot1: 0
   leftHandSlot2: 1
+  leftHandSlot3: 0
 --- !u!222 &8201319159962625297
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -37784,11 +38492,11 @@ RectTransform:
   m_Children:
   - {fileID: 2974136224989464683}
   m_Father: {fileID: 2974136225425912081}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 60, y: -228.97835}
+  m_AnchoredPosition: {x: 50, y: -228.97835}
   m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8201319159962625309
@@ -37922,7 +38630,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8201319160160450548
 RectTransform:
   m_ObjectHideFlags: 0
@@ -38130,8 +38838,10 @@ MonoBehaviour:
   icon: {fileID: 8201319160228384297}
   rightHandSlot1: 1
   rightHandSlot2: 0
+  rightHandSlot3: 0
   leftHandSlot1: 0
   leftHandSlot2: 0
+  leftHandSlot3: 0
 --- !u!222 &8201319160437592394
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -38280,7 +38990,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 40, y: -108.97835}
+  m_AnchoredPosition: {x: 30, y: -108.97835}
   m_SizeDelta: {x: 20, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8201319160437592438

--- a/Assets/Prefabs/Weapons/Horn.prefab
+++ b/Assets/Prefabs/Weapons/Horn.prefab
@@ -55,15 +55,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7484521728328668487}
-  m_LocalRotation: {x: 0.519748, y: -0.41772267, z: 0.60659796, w: 0.4329072}
-  m_LocalPosition: {x: 0.0132, y: 0.0227, z: 0.1421}
+  m_LocalRotation: {x: -0.47470427, y: -0.56615317, z: -0.4367237, w: 0.51322395}
+  m_LocalPosition: {x: -0.0248, y: -0.0164, z: 0.1236}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3192623100979458484}
   m_Father: {fileID: 4745143545172631648}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 73.094, y: -292.384, z: -198.232}
+  m_LocalEulerAnglesHint: {x: 259.04102, y: -298.857, z: -152.004}
 --- !u!1001 &2767176909629182889
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -150,7 +150,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9b6ec872f5fb3742923228c6065eb23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  currentWeaponDamage: 25
+  characterManager: {fileID: 0}
+  enabledDamageColliderOnStartUp: 0
+  teamIDNumber: 0
+  poiseBreak: 0
+  offensivePoiseBonus: 0
+  physicalDamage: 0
+  fireDamage: 0
 --- !u!4 &3192623100979458484 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 731981687516979741, guid: 3441d49fa3ca7744a95e9dfd2aba3f54, type: 3}

--- a/Assets/Scripts/CharacterInventoryManager.cs
+++ b/Assets/Scripts/CharacterInventoryManager.cs
@@ -27,10 +27,6 @@ namespace SoulsLike {
         public int currentLeftWeaponIndex;
         public int currentSpellIndex;
         public int currentConsumableIndex;
-        protected int rightWeaponUsedSize = 0;
-        protected int leftWeaponUsedSize = 0;
-        protected int spellUsedSize = 0;
-        protected int consumableUsedSize = 0;
 
         private void Awake() {
             characterWeaponSlotManager = GetComponent<CharacterWeaponSlotManager>();
@@ -42,14 +38,6 @@ namespace SoulsLike {
 
         private void Start() {
             characterWeaponSlotManager.LoadBothWeaponsOnSlots();
-            for (int i = 0; i < weaponsInRightHandSlots.Length; i++) {
-                if (weaponsInLeftHandSlots[i] != null) leftWeaponUsedSize++;
-                if (weaponsInRightHandSlots[i] != null) rightWeaponUsedSize++;
-            }
-            for (int i = 0; i < memorizedSpells.Length; i++) {
-                if (memorizedSpells[i] != null) spellUsedSize++;
-                if (selectedConsumables[i] != null) consumableUsedSize++;
-            }
         }
     }
 }

--- a/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
+++ b/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
@@ -83,6 +83,9 @@ namespace SoulsLike {
             }
         }
 
+        public virtual void LoadSpellOnSlot(SpellItem spellItem) {
+        }
+
         // 현재 각 손의 WeaponHolderSlot 스크립트를 참조하여 현재 들려있는 무기를 로드
         public virtual void LoadWeaponOnSlot(WeaponItem weaponItem, bool isLeft) {
             if (weaponItem != null) {

--- a/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
@@ -67,7 +67,7 @@ namespace SoulsLike {
         #region Input Actions
         public void HandleRBAction() {
             playerAnimatorManager.EraseHandIKForWeapon();
-            
+
             if (playerInventoryManager.rightWeapon.isMeleeWeapon) {
                 PerformRBMeleeAction();
             } else if (playerInventoryManager.rightWeapon.isMagicCaster || playerInventoryManager.rightWeapon.isFaithCaster || playerInventoryManager.rightWeapon.isPyroCaster) {
@@ -107,16 +107,20 @@ namespace SoulsLike {
         private void PerformRBSpellAction(WeaponItem weapon) {
             if (playerManager.isInteracting) return;
             if (weapon.isFaithCaster) {
-                if (playerInventoryManager.currentSpell != null && playerInventoryManager.currentSpell.isFaithSpell) {
+                if (playerInventoryManager.currentSpell.isFaithSpell) {
                     if (playerStatsManager.currentFocus >= playerInventoryManager.currentSpell.focusCost)
                         playerInventoryManager.currentSpell.AttemptToCastSpell(playerAnimatorManager, playerStatsManager, playerWeaponSlotManager);
                     else playerAnimatorManager.PlayTargetAnimation("Shrugging", true);
+                } else {
+                    playerAnimatorManager.PlayTargetAnimation("Shrugging", true);
                 }
             } else if (weapon.isPyroCaster) {
-                if (playerInventoryManager.currentSpell != null && playerInventoryManager.currentSpell.isPyroSpell) {
+                if (playerInventoryManager.currentSpell.isPyroSpell) {
                     if (playerStatsManager.currentFocus >= playerInventoryManager.currentSpell.focusCost)
                         playerInventoryManager.currentSpell.AttemptToCastSpell(playerAnimatorManager, playerStatsManager, playerWeaponSlotManager);
                     else playerAnimatorManager.PlayTargetAnimation("Shrugging", true);
+                } else {
+                    playerAnimatorManager.PlayTargetAnimation("Shrugging", true);
                 }
             }
         }

--- a/Assets/Scripts/Player/Managers/PlayerInventoryManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerInventoryManager.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 namespace SoulsLike {
     public class PlayerInventoryManager : CharacterInventoryManager {
         public List<WeaponItem> weaponsInventory; // 플레이어의 인벤토리
-        
         public void ChangeRightWeapon() {
             currentRightWeaponIndex += 1; // 다음인덱스로 넘어간다.
             // 배열의 인덱스가 범위를 벗어나면 무장해제 한다.
@@ -47,10 +46,17 @@ namespace SoulsLike {
             } else {
                 currentSpell = memorizedSpells[currentSpellIndex];
             }
+            characterWeaponSlotManager.LoadSpellOnSlot(currentSpell);
         }
 
-        public void ChangeConsumableItem(){
-
+        public void ChangeConsumableItem() {
+            currentConsumableIndex += 1;
+            if (selectedConsumables[currentConsumableIndex] == null || currentConsumableIndex >= selectedConsumables.Length) {
+                currentConsumableIndex = 0;
+                currentConsumable = selectedConsumables[currentConsumableIndex];
+            } else {
+                currentConsumable = selectedConsumables[currentConsumableIndex];
+            }
         }
 
     }

--- a/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
@@ -25,6 +25,10 @@ namespace SoulsLike {
             cameraHandler = FindObjectOfType<CameraHandler>();
         }
 
+        public override void LoadSpellOnSlot(SpellItem spellItem) {
+            quickSlots.UpdateCurrentSpellIcon(spellItem);
+        }
+
         public override void LoadWeaponOnSlot(WeaponItem weaponItem, bool isLeft) {
             if (weaponItem != null) {
                 if (isLeft) {

--- a/Assets/Scripts/UI/EquipmentWindowUI.cs
+++ b/Assets/Scripts/UI/EquipmentWindowUI.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 namespace SoulsLike {
     public class EquipmentWindowUI : MonoBehaviour {
-        public bool rightHandSlot1, rightHandSlot2;
-        public bool leftHandSlot1, leftHandSlot2;
+        public bool rightHandSlot1, rightHandSlot2, rightHandSlot3;
+        public bool leftHandSlot1, leftHandSlot2, leftHandSlot3;
         public HandEquipmentSlotUI[] handEquipmentSlotUI;
 
         // 다크소울 처럼 오른손과 왼손에 각각 여러개의 무기들을 지니고있음
@@ -16,10 +16,14 @@ namespace SoulsLike {
                     handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInRightHandSlots[0]);
                 } else if (handEquipmentSlotUI[i].rightHandSlot2) {
                     handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInRightHandSlots[1]);
+                } else if (handEquipmentSlotUI[i].rightHandSlot3) {
+                    handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInRightHandSlots[2]);
                 } else if (handEquipmentSlotUI[i].leftHandSlot1) {
                     handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInLeftHandSlots[0]);
-                } else {
+                }else if(handEquipmentSlotUI[i].leftHandSlot2){
                     handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInLeftHandSlots[1]);
+                } else {
+                    handEquipmentSlotUI[i].AddItem(playerInventory.weaponsInLeftHandSlots[2]);
                 }
             }
         }
@@ -31,12 +35,20 @@ namespace SoulsLike {
             rightHandSlot2 = true;
         }
 
+        public void SelectRightHandSlt3() {
+            rightHandSlot3 = true;
+        }
+
         public void SelectLeftHandSlot1() {
             leftHandSlot1 = true;
         }
 
         public void SelectLeftHandSlot2() {
             leftHandSlot2 = true;
+        }
+
+        public void SelecteLeftHandSlot3() {
+            leftHandSlot3 = true;
         }
     }
 }

--- a/Assets/Scripts/UI/HandEquipmentSlotUI.cs
+++ b/Assets/Scripts/UI/HandEquipmentSlotUI.cs
@@ -12,8 +12,10 @@ namespace SoulsLike {
 
         public bool rightHandSlot1;
         public bool rightHandSlot2;
+        public bool rightHandSlot3;
         public bool leftHandSlot1;
         public bool leftHandSlot2;
+        public bool leftHandSlot3;
 
         private void Awake() {
             uiManager = FindObjectOfType<UIManager>();
@@ -42,10 +44,14 @@ namespace SoulsLike {
                 uiManager.rightHandSlot1Selected = true;
             } else if (rightHandSlot2) {
                 uiManager.rightHandSlot2Selected = true;
+            } else if (rightHandSlot3) {
+                uiManager.rightHandSlot3Selected = true;
             } else if (leftHandSlot1) {
                 uiManager.leftHandSlot1Selected = true;
-            } else {
+            }else if(leftHandSlot2){
                 uiManager.leftHandSlot2Selected = true;
+            } else {
+                uiManager.leftHandSlot3Selected = true;
             }
         }
     }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -19,8 +19,10 @@ namespace SoulsLike {
         [Header("Equipment Window Slots Selected")]
         public bool rightHandSlot1Selected;
         public bool rightHandSlot2Selected;
+        public bool rightHandSlot3Selected;
         public bool leftHandSlot1Selected; 
         public bool leftHandSlot2Selected;
+        public bool leftHandSlot3Selected;
 
         [Header("Weapon Inventory")]
         public GameObject weaponInventorySlotPrefab; // ½½·Ô prefab

--- a/Assets/Scripts/UI/WeaponInventorySlot.cs
+++ b/Assets/Scripts/UI/WeaponInventorySlot.cs
@@ -51,6 +51,11 @@ namespace SoulsLike {
                 playerInventory.weaponsInRightHandSlots[1] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentRightWeaponIndex == 1) changeNow = true;
+            } else if (uiManager.rightHandSlot3Selected) {
+                playerInventory.weaponsInventory.Add(playerInventory.weaponsInRightHandSlots[1]);
+                playerInventory.weaponsInRightHandSlots[2] = item;
+                playerInventory.weaponsInventory.Remove(item);
+                if (playerInventory.currentRightWeaponIndex == 2) changeNow = true;
             } else if (uiManager.leftHandSlot1Selected) {
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInLeftHandSlots[0]);
                 playerInventory.weaponsInLeftHandSlots[0] = item;
@@ -61,6 +66,11 @@ namespace SoulsLike {
                 playerInventory.weaponsInLeftHandSlots[1] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentLeftWeaponIndex == 1) changeNow = true;
+            } else if (uiManager.leftHandSlot3Selected){
+                playerInventory.weaponsInventory.Add(playerInventory.weaponsInLeftHandSlots[1]);
+                playerInventory.weaponsInLeftHandSlots[2] = item;
+                playerInventory.weaponsInventory.Remove(item);
+                if (playerInventory.currentLeftWeaponIndex == 2) changeNow = true;
             } else {
                 return;
             }


### PR DESCRIPTION
- 장비칸에 왼손 오른손 무기 한칸씩 추가
- 3번째 칸을 클릭하여 무기를 변경하면 2번째 칸의 무기가 인벤토리로 들어가는점 수정 필요
- 스펠을 변경하면 quickSlot의 이미지도 변경되도록 수정
- 소모품도 똑같이 만들것
- 화염병 투척시 특정 각도에서 손에서 바로 터지는점 수정 필요