### PR TITLE
플레이어 UI

### DIFF
--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
@@ -2119,30 +2119,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 396976888}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -2151,6 +2127,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -7763,30 +7751,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1356991353}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -7795,6 +7759,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -19200,7 +19176,7 @@ MonoBehaviour:
   playerInventory: {fileID: 6353349341563976083}
   equipmentWindowUI: {fileID: 8201319159029467312}
   hudWindow: {fileID: 4090091869031233709}
-  selectWindow: {fileID: 8201319158893348181}
+  selectMenuWindow: {fileID: 8201319158893348181}
   equipmentScreenWindow: {fileID: 8201319160132821706}
   weaponInventoryWindow: {fileID: 8201319160069572049}
   rightHandSlot1Selected: 0
@@ -23235,26 +23211,14 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319158893348181}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 2
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -23678,10 +23642,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: CloseWindow
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -35118,7 +35082,6 @@ MonoBehaviour:
   sprintFlag: 0
   comboFlag: 0
   lockOnFlag: 0
-  inventoryFlag: 0
   rollInputTimer: 0
   backstepDelay: 0
   criticalAttackRayCastStartPoint: {fileID: 3287602050738495817}
@@ -37373,26 +37336,14 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319158893348181}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -37769,30 +37720,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 8201319158972659104}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -37801,6 +37728,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -38023,30 +37962,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 8201319159052718495}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -38055,6 +37970,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -38442,30 +38369,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 8201319159962625296}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -38474,6 +38377,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -38936,30 +38851,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 8201319160069572049}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8201319160132821706}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 8201319160437592393}
         m_TargetAssemblyTypeName: sg.HandEquipmentSlotUI, Assembly-CSharp
         m_MethodName: SelectThisSlot
@@ -38968,6 +38859,18 @@ MonoBehaviour:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1796795119284244419}
+        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
+        m_MethodName: OpenSelectedWindow
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0

--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -33,7 +33,7 @@ namespace SoulsLike {
         public bool sprintFlag;
         public bool comboFlag;
         public bool lockOnFlag;
-        public bool inventoryFlag;
+        //public bool inventoryFlag;
 
         public float rollInputTimer; // 다크소울 처럼 tap할 경우 구르고, 계속 누르고있을시 달리도록 하기위한 타이머
         public float backstepDelay;
@@ -205,16 +205,24 @@ namespace SoulsLike {
         }
 
         private void HandleInventoryInput() {
+            //if (inventory_Input) {
+            //    inventoryFlag = !inventoryFlag;
+            //    if (inventoryFlag) {
+            //        uiManager.OpenSelectWindow();
+            //        uiManager.UpdateUI(); // 인벤토리 업데이트
+            //        uiManager.hudWindow.SetActive(false); // 인벤토리가 열리면 HUD를 끈다.
+            //    } else {
+            //        uiManager.CloseSelectWindow();
+            //        uiManager.CloseAllInventoryWindows();
+            //        uiManager.hudWindow.SetActive(true); // 인벤토리가 닫히면 HUD를 킨다.
+            //    }
+            //}
             if (inventory_Input) {
-                inventoryFlag = !inventoryFlag;
-                if (inventoryFlag) {
-                    uiManager.OpenSelectWindow();
-                    uiManager.UpdateUI(); // 인벤토리 업데이트
-                    uiManager.hudWindow.SetActive(false); // 인벤토리가 열리면 HUD를 끈다.
+                if (uiManager.uiStack.Count <= 1) {
+                    uiManager.OpenSelectedWindow(0);
+                    uiManager.UpdateUI();
                 } else {
-                    uiManager.CloseSelectWindow();
-                    uiManager.CloseAllInventoryWindows();
-                    uiManager.hudWindow.SetActive(true); // 인벤토리가 닫히면 HUD를 킨다.
+                    uiManager.CloseWindow();
                 }
             }
         }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -8,11 +8,11 @@ namespace SoulsLike {
         public PlayerInventoryManager playerInventory;
         public EquipmentWindowUI equipmentWindowUI;
         private QuickSlots quickSlots;
-        public Stack uiStack = new();
+        public Stack<GameObject> uiStack = new();
 
         [Header("UI Windows")]
         public GameObject hudWindow;
-        public GameObject selectWindow;
+        public GameObject selectMenuWindow;
         public GameObject equipmentScreenWindow;
         public GameObject weaponInventoryWindow;
 
@@ -21,7 +21,7 @@ namespace SoulsLike {
         public bool rightHandSlot1Selected;
         public bool rightHandSlot2Selected;
         public bool rightHandSlot3Selected;
-        public bool leftHandSlot1Selected; 
+        public bool leftHandSlot1Selected;
         public bool leftHandSlot2Selected;
         public bool leftHandSlot3Selected;
 
@@ -31,6 +31,8 @@ namespace SoulsLike {
         WeaponInventorySlot[] weaponInventorySlots; // 인벤토리 슬롯 배열
 
         private void Awake() {
+            // 게임이 시작되면 Player 의 HUD를 UI 관리를 위한 스택에 제일 먼저 추가
+            uiStack.Push(hudWindow);
             quickSlots = GetComponentInChildren<QuickSlots>();
         }
 
@@ -58,18 +60,28 @@ namespace SoulsLike {
             #endregion
         }
 
-        public void OpenSelectWindow() {
-            selectWindow.SetActive(true);
+        public void OpenSelectedWindow(int code) {
+            uiStack.Peek().SetActive(false);
+            switch (code) {
+                case 0:
+                    selectMenuWindow.SetActive(true);
+                    uiStack.Push(selectMenuWindow);
+                    break;
+                case 1:
+                    weaponInventoryWindow.SetActive(true);
+                    uiStack.Push(weaponInventoryWindow);
+                    break;
+                case 2:
+                    equipmentScreenWindow.SetActive(true);
+                    uiStack.Push(equipmentScreenWindow);
+                    break;
+            }
         }
-
-        public void CloseSelectWindow() {
-            selectWindow.SetActive(false);
-        }
-
-        public void CloseAllInventoryWindows() {
-            ResetAllSelectedSlots();
-            weaponInventoryWindow.SetActive(false);
-            equipmentScreenWindow.SetActive(false);
+        
+        public void CloseWindow() {
+            uiStack.Peek().SetActive(false); // 가장 위에 열려있던 창을 닫는다
+            uiStack.Pop();
+            uiStack.Peek().SetActive(true); // 바로 다음 창을 다시 표시
         }
 
         // 이전에 선택됐던 장비창의 슬롯을 초기화한다.

--- a/Assets/Scripts/UI/WeaponInventorySlot.cs
+++ b/Assets/Scripts/UI/WeaponInventorySlot.cs
@@ -35,11 +35,13 @@ namespace SoulsLike {
         }
 
         bool changeNow = false;
+        WeaponItem mem;
         public void EquipThisItem() {
             // 만약 오른쪽손 슬롯1을 선택하여 플레이어 무기 인벤토리로 들어갔다면
             if (uiManager.rightHandSlot1Selected) {
                 // 무기 인벤토리에 현재 오른쪽손 슬롯1에 장착된 무기를 추가
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInRightHandSlots[0]);
+                mem = playerInventory.weaponsInRightHandSlots[0];
                 // 오른쪽손 슬롯1에는 무기 인벤토리에서 선택된 아이템을 추가
                 playerInventory.weaponsInRightHandSlots[0] = item;
                 // 무기 인벤토리에서 선택된 아이템은 무기 인벤토리에서 제거
@@ -48,32 +50,40 @@ namespace SoulsLike {
                 if (playerInventory.currentRightWeaponIndex == 0) changeNow = true; // 바로 바꿔줘야함
             } else if (uiManager.rightHandSlot2Selected) {
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInRightHandSlots[1]);
+                mem = playerInventory.weaponsInRightHandSlots[1];
                 playerInventory.weaponsInRightHandSlots[1] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentRightWeaponIndex == 1) changeNow = true;
             } else if (uiManager.rightHandSlot3Selected) {
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInRightHandSlots[2]);
+                mem = playerInventory.weaponsInRightHandSlots[2];
                 playerInventory.weaponsInRightHandSlots[2] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentRightWeaponIndex == 2) changeNow = true;
             } else if (uiManager.leftHandSlot1Selected) {
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInLeftHandSlots[0]);
+                mem = playerInventory.weaponsInLeftHandSlots[0];
                 playerInventory.weaponsInLeftHandSlots[0] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentLeftWeaponIndex == 0) changeNow = true;
             } else if (uiManager.leftHandSlot2Selected) {
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInLeftHandSlots[1]);
+                mem = playerInventory.weaponsInLeftHandSlots[1];
                 playerInventory.weaponsInLeftHandSlots[1] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentLeftWeaponIndex == 1) changeNow = true;
             } else if (uiManager.leftHandSlot3Selected){
                 playerInventory.weaponsInventory.Add(playerInventory.weaponsInLeftHandSlots[2]);
+                mem = playerInventory.weaponsInLeftHandSlots[2];
                 playerInventory.weaponsInLeftHandSlots[2] = item;
                 playerInventory.weaponsInventory.Remove(item);
                 if (playerInventory.currentLeftWeaponIndex == 2) changeNow = true;
             } else {
                 return;
             }
+
+            item = mem;
+            icon.sprite = mem.itemIcon;
 
             if (changeNow) {
                 playerInventory.rightWeapon = playerInventory.weaponsInRightHandSlots[playerInventory.currentRightWeaponIndex];


### PR DESCRIPTION
# InputHandler
- 기존에는 inventoryFlag 라는 bool 변수를 이용
- Flag 가 true 일 경우 inventory 버튼의 입력이 들어오게 되면 Flag 값을 반전시킨 후 메뉴 선택창을 화면에 출력
- Flag 가 false 일 경우 inventroy 버튼의 입력이 들어오게 되면 Flag 값을 반전시킨 후 모든 창을 닫은후 플레이어의 HUD를 화면에 다시 출력
- 따라서 기존에 장비창에서 무기를 변경하면 변경과 동시에 모든 창이 닫힘에도 다시 Esc 버튼을 입력해야 HUD가 표시됐었음
- 그냥 Stack 으로 UI들을 관리 하도록 변경
- 게임이 시작되면 기본적으로 플레이어의 HUD는 Stack 에 push 됨
- Stack 의 사이즈가 1 이하라면 Esc 입력이 들어왔을때 메뉴 선택창이 화면에 출력되고 창이 화면에 출력될때마다 Stack 에 push
- 또한 push 직전에 기존의 Top 을 비활성화 하여 화면에는 하나의 창만 표시되도록 함
- 화면에 창이 하나라도 떠있다면(Stack 의 사이즈가 2 이상이라면) Esc 입력이 들어왔을때 Top 부터 Pop
- 각 Ui 버튼의 동작 자체는 동일

# UIManager
- int 값을 매개변수로 받아 매개변수에 따른 UI를 화면에 출력하는 함수
- Stack 의 Top 부터 화면에 표시된 UI를 하나씩 닫는 함수

# WeaponInventorySlot
- 장비창에서 슬롯을 선택해 무기를 변경하고 나면, 모든 UI 창을 닫고 다시 인벤토리를 열기 전까지 인벤토리에 바뀐 장비가 반영되지 않았던 점 해결