### PR TITLE
플레이어 UI

### DIFF
--- a/Assets/Data/Items/Weapons/Axe.asset
+++ b/Assets/Data/Items/Weapons/Axe.asset
@@ -16,6 +16,7 @@ MonoBehaviour:
   itemName: Axe
   modelPrefab: {fileID: 6286975738734905360, guid: cdddfa5d5ff0e6149bce57e9f379242c, type: 3}
   isUnarmed: 0
+  flavorText: "\uD3C9\uBC94\uD55C \uC1E0\uB3C4\uB07C."
   physicalDamage: 25
   fireDamage: 0
   criticalDamageMultiplier: 4

--- a/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
+++ b/Assets/Data/NPCActions/NPCScripts/Rogue/Scenes/SampleScene.unity
@@ -342,6 +342,43 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &65248385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 65248386}
+  m_Layer: 5
+  m_Name: Item Info WIndow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &65248386
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 65248385}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 411147140}
+  m_Father: {fileID: 8201319159806264474}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &74697091
 GameObject:
   m_ObjectHideFlags: 0
@@ -2267,6 +2304,99 @@ NavMeshAgent:
   m_BaseOffset: 0
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
+--- !u!1 &411147139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 411147140}
+  - component: {fileID: 411147142}
+  - component: {fileID: 411147141}
+  - component: {fileID: 411147143}
+  m_Layer: 5
+  m_Name: Item Info
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &411147140
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411147139}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 582927945}
+  - {fileID: 763282057}
+  m_Father: {fileID: 65248386}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 600, y: 800}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &411147141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411147139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21568628, g: 0.21568628, b: 0.21568628, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &411147142
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411147139}
+  m_CullTransparentMesh: 1
+--- !u!114 &411147143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411147139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 937bd1232eaac3342bf5026373f375f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemImage: {fileID: 582927946}
+  itemText: {fileID: 763282058}
 --- !u!1 &427120423
 GameObject:
   m_ObjectHideFlags: 0
@@ -3201,6 +3331,82 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &582927944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 582927945}
+  - component: {fileID: 582927947}
+  - component: {fileID: 582927946}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &582927945
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 582927944}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 411147140}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 218}
+  m_SizeDelta: {x: 500, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &582927946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 582927944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &582927947
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 582927944}
+  m_CullTransparentMesh: 1
 --- !u!4 &590593802 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 180280064851738995, guid: 149b3944685fe904dbecc8bbece03fb2, type: 3}
@@ -4057,6 +4263,86 @@ Transform:
   m_Father: {fileID: 4086121375643061402}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &763282056
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 763282057}
+  - component: {fileID: 763282059}
+  - component: {fileID: 763282058}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &763282057
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763282056}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 411147140}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -185}
+  m_SizeDelta: {x: 500, y: 370}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &763282058
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763282056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 5
+    m_MaxSize: 50
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &763282059
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763282056}
+  m_CullTransparentMesh: 1
 --- !u!1 &765054680
 GameObject:
   m_ObjectHideFlags: 0
@@ -19179,12 +19465,14 @@ MonoBehaviour:
   selectMenuWindow: {fileID: 8201319158893348181}
   equipmentScreenWindow: {fileID: 8201319160132821706}
   weaponInventoryWindow: {fileID: 8201319160069572049}
+  ItemInfoWindow: {fileID: 65248385}
   rightHandSlot1Selected: 0
   rightHandSlot2Selected: 0
   rightHandSlot3Selected: 0
   leftHandSlot1Selected: 0
   leftHandSlot2Selected: 0
   leftHandSlot3Selected: 0
+  handSlotIsSelected: 0
   weaponInventorySlotPrefab: {fileID: 8201319160697999624}
   weaponInventorySlotsParent: {fileID: 8201319160572957559}
 --- !u!222 &1796795120095012171
@@ -23642,9 +23930,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1796795119284244419}
-        m_TargetAssemblyTypeName: SoulsLike.UIManager, Assembly-CSharp
-        m_MethodName: CloseWindow
+      - m_Target: {fileID: 8201319160697999630}
+        m_TargetAssemblyTypeName: SoulsLike.WeaponInventorySlot, Assembly-CSharp
+        m_MethodName: OnClickButton
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -38232,6 +38520,7 @@ RectTransform:
   m_Children:
   - {fileID: 8201319160132821705}
   - {fileID: 8201319160069572048}
+  - {fileID: 65248386}
   m_Father: {fileID: 8201319160034586977}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -39332,6 +39621,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86393c8afaa7bca469afc9ea83cdc40c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  itemInfoWindowUI: {fileID: 411147143}
   icon: {fileID: 8201319160272092476}
 --- !u!224 &8201319160697999631
 RectTransform:

--- a/Assets/Scripts/ItemInfoWindowUI.cs
+++ b/Assets/Scripts/ItemInfoWindowUI.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+namespace SoulsLike {
+    public class ItemInfoWindowUI : MonoBehaviour {
+        public Image itemImage;
+        public Text itemText;
+
+        public void SetItemInfo(WeaponItem weaponItem) {
+            itemImage.sprite = weaponItem.itemIcon;
+            itemText.text = weaponItem.flavorText;
+        }
+    }
+}

--- a/Assets/Scripts/Items/Weapons/WeaponItem.cs
+++ b/Assets/Scripts/Items/Weapons/WeaponItem.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace SoulsLike {
     // Item이라는 ScriptableObject의 하위항목으로 WeaponItem이라는 ScriptableObject를 만든다.
@@ -9,6 +10,7 @@ namespace SoulsLike {
     public class WeaponItem : Item {
         public GameObject modelPrefab;
         public bool isUnarmed;
+        public string flavorText;
 
         [Header("Damage")]
         public float physicalDamage = 25;

--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -205,18 +205,6 @@ namespace SoulsLike {
         }
 
         private void HandleInventoryInput() {
-            //if (inventory_Input) {
-            //    inventoryFlag = !inventoryFlag;
-            //    if (inventoryFlag) {
-            //        uiManager.OpenSelectWindow();
-            //        uiManager.UpdateUI(); // 인벤토리 업데이트
-            //        uiManager.hudWindow.SetActive(false); // 인벤토리가 열리면 HUD를 끈다.
-            //    } else {
-            //        uiManager.CloseSelectWindow();
-            //        uiManager.CloseAllInventoryWindows();
-            //        uiManager.hudWindow.SetActive(true); // 인벤토리가 닫히면 HUD를 킨다.
-            //    }
-            //}
             if (inventory_Input) {
                 if (uiManager.uiStack.Count <= 1) {
                     uiManager.OpenSelectedWindow(0);

--- a/Assets/Scripts/UI/HandEquipmentSlotUI.cs
+++ b/Assets/Scripts/UI/HandEquipmentSlotUI.cs
@@ -53,6 +53,8 @@ namespace SoulsLike {
             } else {
                 uiManager.leftHandSlot3Selected = true;
             }
+
+            uiManager.handSlotIsSelected = true;
         }
     }
 }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -15,6 +15,7 @@ namespace SoulsLike {
         public GameObject selectMenuWindow;
         public GameObject equipmentScreenWindow;
         public GameObject weaponInventoryWindow;
+        public GameObject ItemInfoWindow;
 
         // 어떤 슬롯을 선택해서 인벤토리 창에 들어왔는지 추적할 수 있도록
         [Header("Equipment Window Slots Selected")]
@@ -24,6 +25,8 @@ namespace SoulsLike {
         public bool leftHandSlot1Selected;
         public bool leftHandSlot2Selected;
         public bool leftHandSlot3Selected;
+
+        public bool handSlotIsSelected = false;
 
         [Header("Weapon Inventory")]
         public GameObject weaponInventorySlotPrefab; // 슬롯 prefab
@@ -75,9 +78,13 @@ namespace SoulsLike {
                     equipmentScreenWindow.SetActive(true);
                     uiStack.Push(equipmentScreenWindow);
                     break;
+                case 3:
+                    ItemInfoWindow.SetActive(true);
+                    uiStack.Push(ItemInfoWindow);
+                    break;
             }
         }
-        
+
         public void CloseWindow() {
             uiStack.Peek().SetActive(false); // 가장 위에 열려있던 창을 닫는다
             uiStack.Pop();
@@ -92,6 +99,8 @@ namespace SoulsLike {
             leftHandSlot1Selected = false;
             leftHandSlot2Selected = false;
             leftHandSlot3Selected = false;
+
+            handSlotIsSelected = false;
         }
     }
 }

--- a/Assets/Scripts/UI/WeaponInventorySlot.cs
+++ b/Assets/Scripts/UI/WeaponInventorySlot.cs
@@ -7,8 +7,10 @@ namespace SoulsLike {
     public class WeaponInventorySlot : MonoBehaviour {
         PlayerInventoryManager playerInventory;
         PlayerWeaponSlotManager weaponSlotManager;
-        UIManager uiManager; 
-
+        UIManager uiManager;
+        
+        public ItemInfoWindowUI itemInfoWindowUI;
+        
         // 슬롯은 아이콘과 아이템을 갖는다.
         public Image icon;
         WeaponItem item;
@@ -81,7 +83,7 @@ namespace SoulsLike {
             } else {
                 return;
             }
-
+            Debug.Log(mem);
             item = mem;
             icon.sprite = mem.itemIcon;
 
@@ -96,7 +98,19 @@ namespace SoulsLike {
             weaponSlotManager.LoadWeaponOnSlot(playerInventory.leftWeapon, true);
 
             uiManager.equipmentWindowUI.LoadWeaponOnEquipmentScreen(playerInventory);
+        }
+        
+        public void OnClickButton() {
+            if (uiManager.handSlotIsSelected) uiManager.CloseWindow();
+            else ShowItemInfo();
             uiManager.ResetAllSelectedSlots();
         }
+
+        public void ShowItemInfo() {
+            Debug.Log(item);
+            uiManager.OpenSelectedWindow(3);
+            itemInfoWindowUI.SetItemInfo(item);
+        }
+
     }
 }


### PR DESCRIPTION
- 아이템의 설명을 화면에 출력할 UI 추가
- 인벤토리 창에서 아이템을 클릭하면 플레이버 텍스트와 아이템의 이미지가 들어가있는 윈도우가 화면에 출력된다
- 장비창에서 왼손, 오른손 슬롯을 선택하고 무기를 교체하지 않고 창을 닫을경우 슬롯이 선택된 상태로 남아있는문제 해결 필요