### PR TITLE
# 플레이어 UI

### DIFF
--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -86,6 +86,7 @@ namespace SoulsLike {
         }
 
         public void CloseWindow() {
+            if (uiStack.Peek() == weaponInventoryWindow) ResetAllSelectedSlots();
             uiStack.Peek().SetActive(false); // 가장 위에 열려있던 창을 닫는다
             uiStack.Pop();
             uiStack.Peek().SetActive(true); // 바로 다음 창을 다시 표시


### PR DESCRIPTION
- 장비창에서 왼손, 오른손 슬롯을 선택하고 무기를 교체하지 않고 창을 닫을경우 슬롯이 선택된 상태로 남아있는문제 해결