### PR TITLE
Netcode

### DIFF
--- a/Assets/Plugins/ParrelSync/ScriptableObjects/ParrelSyncProjectSettings.asset
+++ b/Assets/Plugins/ParrelSync/ScriptableObjects/ParrelSyncProjectSettings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0011418c9d75434988a06b6df93b283, type: 3}
+  m_Name: ParrelSyncProjectSettings
+  m_EditorClassIdentifier: 
+  m_OptionalSymbolicLinkFolders: []

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -8226,6 +8226,7 @@ GameObject:
   - component: {fileID: 6482744793811343847}
   - component: {fileID: 6482744793811343846}
   - component: {fileID: 9055956360778353763}
+  - component: {fileID: -9156894317315943495}
   m_Layer: 11
   m_Name: Player
   m_TagString: Character
@@ -8431,9 +8432,6 @@ MonoBehaviour:
   totalFireDamageAbsorption: 0
   isDead: 0
   level: 10
-  healthBar: {fileID: 0}
-  staminaBar: {fileID: 0}
-  focusBar: {fileID: 0}
   staminaRegenerationAmount: 50
   staminaRegenerationTimer: 0
 --- !u!114 &4086121375157841885
@@ -8473,6 +8471,7 @@ MonoBehaviour:
   isMoving: 0
   isFiringSpell: 0
   pendingCriticalDamage: 0
+  inputHandler: {fileID: 0}
   interactableUIGameObject: {fileID: 0}
   itemInteractableGameObject: {fileID: 0}
   dialogUI: {fileID: 0}
@@ -8690,3 +8689,15 @@ MonoBehaviour:
   AlwaysReplicateAsRoot: 0
   DontDestroyWithOwner: 0
   AutoObjectParentSync: 1
+--- !u!114 &-9156894317315943495
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4086121375157841863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cec649750cf5214bb8dd5d1024d8fc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/World Network Manager.prefab
+++ b/Assets/Prefabs/World Network Manager.prefab
@@ -1,0 +1,111 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &876123784018866807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 876123784018866805}
+  - component: {fileID: 876123784018866804}
+  - component: {fileID: 876123784018866802}
+  - component: {fileID: 876123784018866803}
+  m_Layer: 0
+  m_Name: World Network Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &876123784018866805
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 876123784018866807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1036.9756, y: 496.25598, z: -47.50092}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &876123784018866804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 876123784018866807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RunInBackground: 1
+  LogLevel: 1
+  NetworkConfig:
+    ProtocolVersion: 0
+    NetworkTransport: {fileID: 876123784018866802}
+    PlayerPrefab: {fileID: 4086121375157841863, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
+    NetworkPrefabs: []
+    TickRate: 30
+    ClientConnectionBufferTimeout: 10
+    ConnectionApproval: 0
+    ConnectionData: 
+    EnableTimeResync: 0
+    TimeResyncInterval: 30
+    EnsureNetworkVariableLengthSafety: 0
+    EnableSceneManagement: 1
+    ForceSamePrefabs: 1
+    RecycleNetworkIds: 1
+    NetworkIdRecycleDelay: 120
+    RpcHashSize: 0
+    LoadSceneTimeOut: 120
+    SpawnTimeout: 1
+    EnableNetworkLogs: 1
+--- !u!114 &876123784018866802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 876123784018866807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ProtocolType: 0
+  m_MaxPacketQueueSize: 128
+  m_MaxPayloadSize: 6144
+  m_HeartbeatTimeoutMS: 500
+  m_ConnectTimeoutMS: 1000
+  m_MaxConnectAttempts: 60
+  m_DisconnectTimeoutMS: 30000
+  ConnectionData:
+    Address: 127.0.0.1
+    Port: 7777
+    ServerListenAddress: 
+  DebugSimulator:
+    PacketDelayMS: 0
+    PacketJitterMS: 0
+    PacketDropRate: 0
+--- !u!114 &876123784018866803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 876123784018866807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64a93b2a4b84d0b44952c6209782249f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startGameAsClient: 0
+  shutdownNetwork: 0

--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -217,7 +217,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &160348009
+--- !u!1 &363725151
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -225,92 +225,96 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 160348011}
-  - component: {fileID: 160348010}
-  - component: {fileID: 160348012}
+  - component: {fileID: 363725155}
+  - component: {fileID: 363725154}
+  - component: {fileID: 363725153}
+  - component: {fileID: 363725152}
   m_Layer: 0
-  m_Name: World Network Manager
+  m_Name: Plane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &160348010
-MonoBehaviour:
+--- !u!64 &363725152
+MeshCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 160348009}
+  m_GameObject: {fileID: 363725151}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  RunInBackground: 1
-  LogLevel: 1
-  NetworkConfig:
-    ProtocolVersion: 0
-    NetworkTransport: {fileID: 160348012}
-    PlayerPrefab: {fileID: 4086121375157841863, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
-    NetworkPrefabs: []
-    TickRate: 30
-    ClientConnectionBufferTimeout: 10
-    ConnectionApproval: 0
-    ConnectionData: 
-    EnableTimeResync: 0
-    TimeResyncInterval: 30
-    EnsureNetworkVariableLengthSafety: 0
-    EnableSceneManagement: 1
-    ForceSamePrefabs: 1
-    RecycleNetworkIds: 1
-    NetworkIdRecycleDelay: 120
-    RpcHashSize: 0
-    LoadSceneTimeOut: 120
-    SpawnTimeout: 1
-    EnableNetworkLogs: 1
---- !u!4 &160348011
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &363725153
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 363725151}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &363725154
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 363725151}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &363725155
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 160348009}
+  m_GameObject: {fileID: 363725151}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1036.9756, y: 496.25598, z: -47.50092}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &160348012
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 160348009}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ProtocolType: 0
-  m_MaxPacketQueueSize: 128
-  m_MaxPayloadSize: 6144
-  m_HeartbeatTimeoutMS: 500
-  m_ConnectTimeoutMS: 1000
-  m_MaxConnectAttempts: 60
-  m_DisconnectTimeoutMS: 30000
-  ConnectionData:
-    Address: 127.0.0.1
-    Port: 7777
-    ServerListenAddress: 
-  DebugSimulator:
-    PacketDelayMS: 0
-    PacketJitterMS: 0
-    PacketDropRate: 0
 --- !u!1 &435908515
 GameObject:
   m_ObjectHideFlags: 0
@@ -1516,3 +1520,60 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2088266561}
   m_CullTransparentMesh: 1
+--- !u!1001 &876123783859635486
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1036.9756
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 496.25598
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -47.50092
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 876123784018866807, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
+      propertyPath: m_Name
+      value: World Network Manager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}

--- a/Assets/Scenes/WorldScene_01.unity
+++ b/Assets/Scenes/WorldScene_01.unity
@@ -476,7 +476,6 @@ MonoBehaviour:
   radius: 0.75
   interactableText: 
   isIgnited: 0
-  playerUIManager: {fileID: 0}
 --- !u!1 &20219544
 GameObject:
   m_ObjectHideFlags: 0
@@ -3952,7 +3951,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &327117525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4065,6 +4064,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 1861903321}
   backStabCollider: {fileID: 693741378}
   riposteCollider: {fileID: 1535934053}
@@ -12132,6 +12132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 212062006596600148}
   backStabCollider: {fileID: 134924773518198507}
   riposteCollider: {fileID: 134924773715422354}
@@ -13302,7 +13303,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -20277,7 +20278,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -28427,7 +28428,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1126827549
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -28540,6 +28541,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 1247268872}
   backStabCollider: {fileID: 908486473}
   riposteCollider: {fileID: 984965490}
@@ -31478,7 +31480,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -38192,7 +38194,6 @@ MonoBehaviour:
   radius: 0.75
   interactableText: 
   isIgnited: 0
-  playerUIManager: {fileID: 0}
 --- !u!135 &1419007834
 SphereCollider:
   m_ObjectHideFlags: 0
@@ -44939,7 +44940,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1585748728}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -53457,7 +53458,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -53807,6 +53808,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 841875962}
   backStabCollider: {fileID: 1892301564}
   riposteCollider: {fileID: 1144917034}
@@ -54028,7 +54030,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1921497841
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -54141,6 +54143,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 302588504}
   backStabCollider: {fileID: 1094468347}
   riposteCollider: {fileID: 1269112987}
@@ -67235,7 +67238,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &4198961208678546640
 GameObject:
   m_ObjectHideFlags: 0
@@ -67965,7 +67968,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!136 &5324564050113085468
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -69305,6 +69308,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 6389220527869462209}
   backStabCollider: {fileID: 7294613999552322113}
   riposteCollider: {fileID: 7294614000073953864}
@@ -69497,7 +69501,7 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -70224,6 +70228,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterWeaponSlotManager: {fileID: 0}
+  characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 2173030236879191317}
   backStabCollider: {fileID: 2573975979005223317}
   riposteCollider: {fileID: 2573975977644861852}

--- a/Assets/Scripts/CharacterNetworkManager.cs
+++ b/Assets/Scripts/CharacterNetworkManager.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+
+// 연결되어 있는 플레이어(캐릭터?)의 월드 좌표와 회전값을 구함
+namespace SoulsLike {
+    public class CharacterNetworkManager : NetworkBehaviour {
+        [Header("Network Position")]
+        // 네트워크 상의 좌표는 접속해 있는 모든 사람이 읽을 수 있고, 주인만 수정가능
+        public NetworkVariable<Vector3> networkPosition = new NetworkVariable<Vector3>(Vector3.zero, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public Vector3 networkVelocity;
+        public float networkPositionSmoothTime = 0.1f; // 얼마나 빠르게 실제 위치가 네트워크 상으로 반영될지, 값이 커질수록 느리게 반영되어 마치 순간이동 하는것 처럼 이동
+        public NetworkVariable<Quaternion> networkRotation = new NetworkVariable<Quaternion>(Quaternion.identity, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public float networkRotationSmoothTime = 0.1f;
+    }
+}

--- a/Assets/Scripts/GameSessionManager.cs
+++ b/Assets/Scripts/GameSessionManager.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+namespace SoulsLike {
+    public class GameSessionManager : MonoBehaviour {
+
+        public static GameSessionManager instance;
+
+        // 네트워크 실험용
+        [Header("Debug Join Game")]
+        [SerializeField] bool startGameAsClient;
+        [SerializeField] bool shutdownNetwork;
+
+        private void Awake() {
+            if (instance == null) instance = this;
+            else Destroy(gameObject);
+        }
+
+        private void Update() {
+            if (startGameAsClient) {
+                startGameAsClient = false;
+                NetworkManager.Singleton.StartClient();
+            }
+            if (shutdownNetwork) {
+                shutdownNetwork = false;
+                NetworkManager.Singleton.Shutdown();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/InventoryWindow.cs
+++ b/Assets/Scripts/InventoryWindow.cs
@@ -2,38 +2,39 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class InventoryWindow : MonoBehaviour
-{
-    public GameObject[] allInventoryWindows;
-    public int currentIndex = 0;
+namespace SoulsLike {
+    public class InventoryWindow : MonoBehaviour {
+        public GameObject[] allInventoryWindows;
+        public int currentIndex = 0;
 
-    private void OnDisable() {
-        currentIndex = 0;
-    }
-
-    public void PrintInventoryWindow() {
-        for (int i = 0; i < allInventoryWindows.Length; i++) {
-            allInventoryWindows[i].SetActive(false);
+        private void OnDisable() {
+            currentIndex = 0;
         }
-        allInventoryWindows[currentIndex].SetActive(true);
-    }
 
-    public void NextPage() {
-        if (currentIndex == allInventoryWindows.Length - 1) currentIndex = 0;
-        else currentIndex += 1;
+        public void PrintInventoryWindow() {
+            for (int i = 0; i < allInventoryWindows.Length; i++) {
+                allInventoryWindows[i].SetActive(false);
+            }
+            allInventoryWindows[currentIndex].SetActive(true);
+        }
 
-        PrintInventoryWindow();
-    }
+        public void NextPage() {
+            if (currentIndex == allInventoryWindows.Length - 1) currentIndex = 0;
+            else currentIndex += 1;
 
-    public void PrevPage() {
-        if (currentIndex == 0) currentIndex = allInventoryWindows.Length - 1;
-        else currentIndex -= 1;
+            PrintInventoryWindow();
+        }
 
-        PrintInventoryWindow();
-    }
+        public void PrevPage() {
+            if (currentIndex == 0) currentIndex = allInventoryWindows.Length - 1;
+            else currentIndex -= 1;
 
-    public void PrintThatInventoryWindow(int index) {
-        currentIndex = index;
-        PrintInventoryWindow();
+            PrintInventoryWindow();
+        }
+
+        public void PrintThatInventoryWindow(int index) {
+            currentIndex = index;
+            PrintInventoryWindow();
+        }
     }
 }

--- a/Assets/Scripts/MainMenuManager.cs
+++ b/Assets/Scripts/MainMenuManager.cs
@@ -15,8 +15,8 @@ namespace SoulsLike {
             SceneManager.LoadScene(worldSceneIndex);
             PlayerManager player = FindObjectOfType<PlayerManager>();
             if (player != null) {
-                player.transform.position = new Vector3(-3.5f, 4f, -18.99f);
                 UIManager.instance.transform.gameObject.GetComponent<CanvasGroup>().alpha = 1;
+                player.transform.position = new Vector3(-3.5f, 5f, -19f);
             }
         }
     }

--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -112,6 +112,17 @@ namespace SoulsLike {
             inputActions.Disable();
         }
 
+        private void OnApplicationFocus(bool focus) {
+            // 창을 최소화 하면 입력값을 받지 않음
+            // 다시 창을 열면 입력을 받음
+            if (this.enabled) {
+                if (focus) {
+                    inputActions.Enable();
+                } else {
+                    inputActions.Disable();
+                }
+            }
+        }
         // 모든 입력 처리 호출
         public void TickInput(float delta) {
             if (playerStatsManager.isDead) return;

--- a/Assets/Scripts/Player/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerManager.cs
@@ -70,7 +70,9 @@ namespace SoulsLike {
             }
         }
 
-        private void Update() {
+        protected override void Update() {
+            base.Update();
+            if (!IsOwner) return;
             if (isClimbing) {
                 if (leftFoot.position.y > rightFoot.position.y) {
                     rightFootUp = false;
@@ -137,6 +139,7 @@ namespace SoulsLike {
         }
 
         private void LateUpdate() {
+            if (!IsOwner) return;
             // 1프레임당 한번의 호출만 이뤄지도록 한다.
             inputHandler.rollFlag = false;
             inputHandler.rb_Input = false;

--- a/Assets/Scripts/PlayerNetworkManager.cs
+++ b/Assets/Scripts/PlayerNetworkManager.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+
+namespace SoulsLike {
+    public class PlayerNetworkManager : CharacterNetworkManager {
+
+    }
+}


### PR DESCRIPTION
멀티 플레이에서 클라이언트와 호스트 간 오브젝트의 좌표, 회전값을 일치하도록 만듬

# GameSessionManager
- 타이틀 화면에서 New game 버튼을 누르면 호스트로서 네트워크를 시작
- shutdownNetwork 변수는 true 가 되면 현재의 호스트로서의 네트워크를 종료한다
- startGameAsClient 변수가 true가 되면 클라이언트로 네트워크를 시작

# CharacterNetworkManager
- 네트워크에 접속해있을때의 캐릭터의 좌표와 속도, 회전값 그리고 그에대한 반영속도를 관리하는 클래스
- 좌표와 회전값은 오로지 오브젝트의 주인만 수정할 수 있으며 값을 읽는것은 네트워크상 모든 클라이언트가 가능

# InputHandler
- 두개의 프로젝트로 테스트를 하기위한 OnApplicationFocus 메소드
- 어떤 프로젝트의 창이 최소화가 되면 해당 프로젝트는 입력을 받지 않음
- 다시 창을 열었을때 입력을 받음

# CharacterManager
- 클라이언트가 오브젝트의 주인이라면 네트워크 좌표와 회전값을 변경 가능
- 오브젝트의 주인이 해당 클라이언트가 아니라면 네트워크 좌표와 회전값을 복사함

# PlayerManager
- 오브젝트의 주인이 클라이언트가 아니라면 Update 와 LateUpdate 체크를 하지않고 반환