### PR TITLE
Netcode

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -3053,13 +3053,13 @@ AnimatorStateMachine:
     m_Position: {x: 340, y: 180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6576927775200037125}
-    m_Position: {x: 500, y: 330, z: 0}
+    m_Position: {x: 500, y: 320, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7706806318751911367}
-    m_Position: {x: 500, y: 20, z: 0}
+    m_Position: {x: 500, y: 30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8241360423566455227}
-    m_Position: {x: 230, y: -20, z: 0}
+    m_Position: {x: 270, y: 30, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Assets/Scripts/AI/Enemy/Manager/BossManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/BossManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace SoulsLike {
     public class BossManager : MonoBehaviour {
+        Animator animator;
         BossHealthBar bossHealthBar;
         public string bossName;
         EnemyStatsManager enemyStats;
@@ -14,6 +15,7 @@ namespace SoulsLike {
         public GameObject particleFX;
 
         private void Awake() {
+            animator = GetComponent<Animator>();
             bossHealthBar = FindObjectOfType<BossHealthBar>();
             enemyStats = GetComponent<EnemyStatsManager>();
             enemyAnimatorManager = GetComponent<EnemyAnimatorManager>();
@@ -37,8 +39,8 @@ namespace SoulsLike {
 
         //페이즈 전환
         public void ShiftToSecondPhase() {
-            enemyAnimatorManager.anim.SetBool("isInvulnerable", true);
-            enemyAnimatorManager.anim.SetBool("isPhaseShifting", true);
+            animator.SetBool("isInvulnerable", true);
+            animator.SetBool("isPhaseShifting", true);
             enemyAnimatorManager.PlayTargetAnimation("PhaseShift", true);
             //패턴 전환
         }

--- a/Assets/Scripts/AI/Enemy/Manager/EnemyAnimatorManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/EnemyAnimatorManager.cs
@@ -10,7 +10,7 @@ namespace SoulsLike {
         protected override void Awake() {
             base.Awake();
             enemyManager = GetComponent<EnemyManager>();
-            anim = GetComponent<Animator>();
+            enemyManager.anim = GetComponent<Animator>();
             //enemyEffectsManager = GetComponent<EnemyEffectsManager>();
             bossManager = GetComponent<BossManager>();
         }
@@ -21,13 +21,13 @@ namespace SoulsLike {
         private void OnAnimatorMove() {
             float delta = Time.deltaTime;
             enemyManager.enemyRigidbody.drag = 0; // ¹Ì²ô·¯Áü ¹æÁö
-            Vector3 deltaPosition = anim.deltaPosition;
+            Vector3 deltaPosition = enemyManager.anim.deltaPosition;
             deltaPosition.y = 0;
             Vector3 velocity = deltaPosition / delta;
             enemyManager.enemyRigidbody.velocity = velocity;
 
             if (characterManager.isRotatingWithRootMotion) {
-                characterManager.transform.rotation *= anim.deltaRotation;
+                characterManager.transform.rotation *= enemyManager.anim.deltaRotation;
             }
         }
 

--- a/Assets/Scripts/AI/Enemy/Manager/EnemyManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/EnemyManager.cs
@@ -46,16 +46,16 @@ namespace SoulsLike {
             HandleRecoveryTimer();
             HandleStateMachine();
 
-            isUsingLeftHand = enemyAnimatorManager.anim.GetBool("isUsingLeftHand");
-            isUsingRightHand = enemyAnimatorManager.anim.GetBool("isUsingRightHand");
-            isPhaseShifting = enemyAnimatorManager.anim.GetBool("isPhaseShifting");
-            isRotatingWithRootMotion = enemyAnimatorManager.anim.GetBool("isRotatingWithRootMotion");
-            isInteracting = enemyAnimatorManager.anim.GetBool("isInteracting");
-            canDoCombo = enemyAnimatorManager.anim.GetBool("canDoCombo");
-            canRotate = enemyAnimatorManager.anim.GetBool("canRotate");
-            isInvulnerable = enemyAnimatorManager.anim.GetBool("isInvulnerable");
-            enemyAnimatorManager.anim.SetBool("isDead", enemyStatsManager.isDead);
-            enemyAnimatorManager.anim.SetBool("isGrabbed", isGrabbed);
+            isUsingLeftHand = anim.GetBool("isUsingLeftHand");
+            isUsingRightHand = anim.GetBool("isUsingRightHand");
+            isPhaseShifting = anim.GetBool("isPhaseShifting");
+            isRotatingWithRootMotion = anim.GetBool("isRotatingWithRootMotion");
+            isInteracting = anim.GetBool("isInteracting");
+            canDoCombo = anim.GetBool("canDoCombo");
+            canRotate = anim.GetBool("canRotate");
+            isInvulnerable = anim.GetBool("isInvulnerable");
+            anim.SetBool("isDead", enemyStatsManager.isDead);
+            anim.SetBool("isGrabbed", isGrabbed);
         }
 
         private void LateUpdate() {

--- a/Assets/Scripts/AI/Enemy/States/AttackState.cs
+++ b/Assets/Scripts/AI/Enemy/States/AttackState.cs
@@ -47,8 +47,8 @@ namespace SoulsLike {
             //Debug.Log(currentAttack);
             enemyAnimatorManager.PlayTargetAnimation(currentAttack.actionAnimation, true);
             //enemyAnimatorManager.PlayWeaponTrailFX();
-            enemyAnimatorManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
-            enemyAnimatorManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
+            enemyManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
+            enemyManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
             hasPerformedAttack = true;
             RollForComboChance(enemyManager);
             if (!willDoComboOnNextAttack) {
@@ -60,8 +60,8 @@ namespace SoulsLike {
 
         private void AttackTargetWithCombo(EnemyAnimatorManager enemyAnimatorManager, EnemyManager enemyManager) {
             willDoComboOnNextAttack = false;
-            enemyAnimatorManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
-            enemyAnimatorManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
+            enemyManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
+            enemyManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
             //Debug.Log(currentAttack);
             enemyAnimatorManager.PlayTargetAnimation(currentAttack.actionAnimation, true);
             //enemyAnimatorManager.PlayWeaponTrailFX();

--- a/Assets/Scripts/AI/Enemy/States/CombatStanceState.cs
+++ b/Assets/Scripts/AI/Enemy/States/CombatStanceState.cs
@@ -16,13 +16,13 @@ namespace SoulsLike {
         public override State Tick(EnemyManager enemyManager, EnemyStatsManager enemyStats, EnemyAnimatorManager enemyAnimatorManager) {
             if (enemyStats.isDead) return deadState;
             float distanceFromTarget = Vector3.Distance(enemyManager.currentTarget.transform.position, enemyManager.transform.position); // 타겟과의 거리
-            enemyAnimatorManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime); // 앞,뒤 이동
-            enemyAnimatorManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime); // 좌,우 이동
+            enemyManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime); // 앞,뒤 이동
+            enemyManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime); // 좌,우 이동
             attackState.hasPerformedAttack = false; // 전투 태세 -> 플레이어가 적정 사거리 내에 있을 경우 공격 선택 -> 공격
 
             if (enemyManager.isInteracting) { // 행동중이라면 
-                enemyAnimatorManager.anim.SetFloat("Vertical", 0);
-                enemyAnimatorManager.anim.SetFloat("Horizontal", 0);
+                enemyManager.anim.SetFloat("Vertical", 0);
+                enemyManager.anim.SetFloat("Horizontal", 0);
                 return this;
             }
 

--- a/Assets/Scripts/AI/Enemy/States/PursueTargetState.cs
+++ b/Assets/Scripts/AI/Enemy/States/PursueTargetState.cs
@@ -18,14 +18,14 @@ namespace SoulsLike {
 
             // 행동 중이라면
             if (enemyManager.isInteracting) {
-                enemyAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime); // 제자리에 정지
+                enemyManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime); // 제자리에 정지
                 return this;
             }
 
             if (distanceFromTarget <= enemyManager.maximumAggroRadius) { 
                 return combatStanceState;
             } else {
-                enemyAnimatorManager.anim.SetFloat("Vertical", 1, 0.1f, Time.deltaTime);
+                enemyManager.anim.SetFloat("Vertical", 1, 0.1f, Time.deltaTime);
                 return this;
             }
         }

--- a/Assets/Scripts/AI/Enemy/States/RotateTowardsTargetState.cs
+++ b/Assets/Scripts/AI/Enemy/States/RotateTowardsTargetState.cs
@@ -7,8 +7,8 @@ namespace SoulsLike {
         public CombatStanceState combatStanceState;
         public PursueTargetState pursueTargetState;
         public override State Tick(EnemyManager enemyManager, EnemyStatsManager enemyStats, EnemyAnimatorManager enemyAnimatorManager) {
-            enemyAnimatorManager.anim.SetFloat("Vertical", 0);
-            enemyAnimatorManager.anim.SetFloat("Horizontal", 0);
+            enemyManager.anim.SetFloat("Vertical", 0);
+            enemyManager.anim.SetFloat("Horizontal", 0);
 
             Vector3 targetDirection = enemyManager.currentTarget.transform.position - enemyManager.transform.position;
 

--- a/Assets/Scripts/AI/NPC/NPCAnimatorManager.cs
+++ b/Assets/Scripts/AI/NPC/NPCAnimatorManager.cs
@@ -10,19 +10,19 @@ namespace SoulsLike {
         protected override void Awake() {
             base.Awake();
             npcManager = GetComponent<NPCManager>();
-            anim = GetComponent<Animator>();
+            npcManager.anim = GetComponent<Animator>();
         }
 
         private void OnAnimatorMove() {
             float delta = Time.deltaTime;
             npcManager.npcRigidbody.drag = 0;
-            Vector3 deltaPosition = anim.deltaPosition;
+            Vector3 deltaPosition = npcManager.anim.deltaPosition;
             deltaPosition.y = 0;
             Vector3 velocity = deltaPosition / delta;
             npcManager.npcRigidbody.velocity = velocity;
 
             if (characterManager.isRotatingWithRootMotion) {
-                characterManager.transform.rotation *= anim.deltaRotation;
+                characterManager.transform.rotation *= npcManager.anim.deltaRotation;
             }
         }
 

--- a/Assets/Scripts/AI/NPC/NPCManager.cs
+++ b/Assets/Scripts/AI/NPC/NPCManager.cs
@@ -59,15 +59,15 @@ namespace SoulsLike {
             HandleChangeTargetTimer();
             HandleRecoveryTimer();
 
-            isUsingLeftHand = npcAnimatorManager.anim.GetBool("isUsingLeftHand");
-            isUsingRightHand = npcAnimatorManager.anim.GetBool("isUsingRightHand");
-            isRotatingWithRootMotion = npcAnimatorManager.anim.GetBool("isRotatingWithRootMotion");
-            isInteracting = npcAnimatorManager.anim.GetBool("isInteracting");
-            canDoCombo = npcAnimatorManager.anim.GetBool("canDoCombo");
-            canRotate = npcAnimatorManager.anim.GetBool("canRotate");
-            isInvulnerable = npcAnimatorManager.anim.GetBool("isInvulnerable");
-            npcAnimatorManager.anim.SetBool("isDead", npcStatsManager.isDead);
-            npcAnimatorManager.anim.SetBool("isGrabbed", isGrabbed);
+            isUsingLeftHand = anim.GetBool("isUsingLeftHand");
+            isUsingRightHand = anim.GetBool("isUsingRightHand");
+            isRotatingWithRootMotion =anim.GetBool("isRotatingWithRootMotion");
+            isInteracting = anim.GetBool("isInteracting");
+            canDoCombo = anim.GetBool("canDoCombo");
+            canRotate = anim.GetBool("canRotate");
+            isInvulnerable = anim.GetBool("isInvulnerable");
+            anim.SetBool("isDead", npcStatsManager.isDead);
+            anim.SetBool("isGrabbed", isGrabbed);
             if (aggravationToPlayer >= 30 && canTalk) canTalk = false;
         }
 

--- a/Assets/Scripts/AI/NPC/States/NPCAttackState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCAttackState.cs
@@ -44,8 +44,8 @@ namespace SoulsLike {
 
         private void AttackTarget(NPCAnimatorManager npcAnimatorManager, NPCManager npcManager) {
             npcAnimatorManager.PlayTargetAnimation(currentAttack.actionAnimation, true);
-            npcAnimatorManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
-            npcAnimatorManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
+            npcManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
+            npcManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
             hasPerformedAttack = true;
             npcManager.changeTargetTimer = npcManager.changeTargetTime;
             RollForComboChance(npcManager);
@@ -56,8 +56,8 @@ namespace SoulsLike {
         }
         private void AttackTargetWithCombo(NPCAnimatorManager npcAnimatorManager, NPCManager npcManager) {
             willDoComboOnNextAttack = false;
-            npcAnimatorManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
-            npcAnimatorManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
+            npcManager.anim.SetBool("isUsingRightHand", currentAttack.isRightHandedAction);
+            npcManager.anim.SetBool("isUsingLeftHand", !currentAttack.isRightHandedAction);
             npcAnimatorManager.PlayTargetAnimation(currentAttack.actionAnimation, true);
             npcManager.changeTargetTimer = npcManager.changeTargetTime;
             npcManager.currentRecoveryTime = currentAttack.recoveryTime;

--- a/Assets/Scripts/AI/NPC/States/NPCCombatStanceState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCCombatStanceState.cs
@@ -15,12 +15,12 @@ namespace SoulsLike {
         protected float horizontalMovementValue = 0;
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
             float distance = Vector3.Distance(npcManager.transform.position, npcManager.currentTarget.transform.position);
-            npcAnimatorManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime);
-            npcAnimatorManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime);
+            npcManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime);
+            npcManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime);
 
             if (npcManager.isInteracting) {
-                npcAnimatorManager.anim.SetFloat("Vertical", 0);
-                npcAnimatorManager.anim.SetFloat("Horizontal", 0);
+                npcManager.anim.SetFloat("Vertical", 0);
+                npcManager.anim.SetFloat("Horizontal", 0);
                 return this;
             }
 

--- a/Assets/Scripts/AI/NPC/States/NPCIdleState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCIdleState.cs
@@ -12,8 +12,8 @@ namespace SoulsLike {
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
             if (npcManager.targets.Count > 0) npcManager.targets.Clear();
             colliders = Physics.OverlapSphere(npcManager.transform.position, npcManager.detectionRadius, npcManager.hostileLayer);
-            npcAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
-            npcAnimatorManager.anim.SetFloat("Horizontal", 0, 0.1f, Time.deltaTime);
+            npcManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
+            npcManager.anim.SetFloat("Horizontal", 0, 0.1f, Time.deltaTime);
 
             for (int i = 0; i < colliders.Length; i++) {
                 CharacterStatsManager character = colliders[i].transform.GetComponent<CharacterStatsManager>();

--- a/Assets/Scripts/AI/NPC/States/NPCPursueTargetState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCPursueTargetState.cs
@@ -9,7 +9,7 @@ namespace SoulsLike {
         public NPCCombatStanceState npcCombatStanceState;
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
             if (npcManager.isInteracting) {
-                npcAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
+                npcManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
                 return this;
             }
 
@@ -24,7 +24,7 @@ namespace SoulsLike {
             float distance = Vector3.Distance(npcManager.transform.position, npcManager.currentTarget.transform.position);
             if (distance <= npcManager.maximumAggroRadius) return npcCombatStanceState;
             else {
-                npcAnimatorManager.anim.SetFloat("Vertical", 1, 0.1f, Time.deltaTime);
+                npcManager.anim.SetFloat("Vertical", 1, 0.1f, Time.deltaTime);
                 return this;
             }
         }

--- a/Assets/Scripts/AI/NPC/States/NPCRotateTowardsTargetState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCRotateTowardsTargetState.cs
@@ -6,8 +6,8 @@ namespace SoulsLike {
     public class NPCRotateTowardsTargetState : NPCState {
         public NPCCombatStanceState npcCombatStanceState;
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
-            npcAnimatorManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
-            npcAnimatorManager.anim.SetFloat("Horizontal", 0, 0.1f, Time.deltaTime);
+            npcManager.anim.SetFloat("Vertical", 0, 0.1f, Time.deltaTime);
+            npcManager.anim.SetFloat("Horizontal", 0, 0.1f, Time.deltaTime);
 
             Vector3 targetDirection = npcManager.currentTarget.transform.position - npcManager.transform.position;
 

--- a/Assets/Scripts/AI/NPC/States/NPCWanderState.cs
+++ b/Assets/Scripts/AI/NPC/States/NPCWanderState.cs
@@ -9,8 +9,8 @@ namespace SoulsLike {
         protected float verticalMovementValue;
         protected float horizontalMovementValue;
         public override NPCState Tick(NPCManager npcManager, NPCStatsManager npcStatsManager, NPCAnimatorManager npcAnimatorManager) {
-            npcAnimatorManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime);
-            npcAnimatorManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime);
+            npcManager.anim.SetFloat("Vertical", verticalMovementValue, 0.2f, Time.deltaTime);
+            npcManager.anim.SetFloat("Horizontal", horizontalMovementValue, 0.2f, Time.deltaTime);
             HandleRotateTowardsTarget(npcManager);
             int randomValue = Random.Range(0, 50);
             

--- a/Assets/Scripts/CharacterNetworkManager.cs
+++ b/Assets/Scripts/CharacterNetworkManager.cs
@@ -3,15 +3,68 @@ using System.Collections.Generic;
 using UnityEngine;
 using Unity.Netcode;
 
-// 연결되어 있는 플레이어(캐릭터?)의 월드 좌표와 회전값을 구함
 namespace SoulsLike {
     public class CharacterNetworkManager : NetworkBehaviour {
+
+        CharacterManager character;
+        // 연결되어 있는 오브젝트의 월드 좌표와 회전값을 구함
         [Header("Network Position")]
-        // 네트워크 상의 좌표는 접속해 있는 모든 사람이 읽을 수 있고, 주인만 수정가능
+        // 네트워크 상의 좌표는 접속해 있는 모든 사람이 읽을 수 있고, 주인만이 수정가능
         public NetworkVariable<Vector3> networkPosition = new NetworkVariable<Vector3>(Vector3.zero, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public Vector3 networkVelocity;
         public float networkPositionSmoothTime = 0.1f; // 얼마나 빠르게 실제 위치가 네트워크 상으로 반영될지, 값이 커질수록 느리게 반영되어 마치 순간이동 하는것 처럼 이동
         public NetworkVariable<Quaternion> networkRotation = new NetworkVariable<Quaternion>(Quaternion.identity, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public float networkRotationSmoothTime = 0.1f;
+
+        // 게임오브젝트의 주인이라면 내 오브젝트의 값들을 네트워크 변수들에 할당
+        // 주인이 아니라면 네트워크 값들에서 가져와 할당한다.
+        // 누군가의 게임에 합류했다면, 누군가의 게임내에서 나의 오브젝트는 네트워크로부터 값들을 가져와 대입받음
+        // 네트워크에 존재하는 값들은 내 게임에서 나의 오브젝트로부터 값을 할당받은 것
+        [Header("Network Movement Animation")]
+        public NetworkVariable<float> verticalNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<float> horizontalNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<float> moveAmountNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+
+        // sprintFlag 와 lockOnFlag 대체 (내 경우 사다리를 오르내릴때의 블렌드 트리가 따로 있어서 추가해줘야 할듯)
+        // 기본적으로는 게임내의 어떤 다른 사람이 내 게임의 특정 스크립트에서 특정 변수가 변경되는것을 알아낼 방법이 없음
+        // 하지만 네트워크 변수는 한쪽에서 변경될 때마다 모든 클라이언트들에 대해 변경되기 때문에 sprintFlag 와 lockOnFlag를 네트워크 변수로 만들어 사용
+        [Header("Flags")]
+        public NetworkVariable<bool> isSprinting = new NetworkVariable<bool>(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<bool> isLockedOn = new NetworkVariable<bool>(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+
+        protected virtual void Awake() {
+            character = GetComponent<CharacterManager>();
+        }
+        
+        // RPC(Remote Procedure Call) : 원격 프로시저 호출
+        // 원격제어를 위한 코딩없이 다른 주소 공간에서 함수나 프로시저를 실행할 수 있게 하는 프로세스 간 통신 기술
+
+        // 서버RPC : 어떤 클라이언트인지 상관없이 클라이언트로 부터 서버로 전달되는 메시지
+        [ServerRpc]
+        public void NotifyServerOfAnimationServerRpc(ulong clientID, string animationID, bool isInteracting) {
+            // 서버만이 클라이언트RPC 수행 가능
+            if (IsServer) { // 현재 내가 서버라면(호스트라면?)
+                // 클라이언트가 연결된 다른 모든 클라이언트들에서 애니메이션을 수행하도록 한다.
+                ProcessAllClientsAnimationClientRpc(clientID, animationID, isInteracting);
+            }
+        }
+
+        // 클라이언트RPC : 서버로부터 하나의 클라이언트 혹은 모든 클라이언트 들에게 전달되는 메시지
+        [ClientRpc]
+        // 만약 내 오브젝트가 애니메이션을 재생중이라면 연결된 다른 모든 클라이언트들에게 이 오브젝트가 애니메이션을 재생하고 있다는 사실을 알려줌
+        private void ProcessAllClientsAnimationClientRpc(ulong clientID, string animationID, bool isInteracting) {
+            // 내 단말에서 내가 애니메이션을 수행했을 때, 다른 클라이언트의 내 오브젝트가 애니메이션을 수행 한 후
+            // 클라이언트RPC에 의해 내 단말에서 또다시 애니메이션을 수행하지 않도록 클라이언트 id가 다른 경우에만
+            if (clientID != NetworkManager.Singleton.LocalClientId) {
+                // 애니메이션 수행
+                PerformAnimationFromServer(animationID, isInteracting);
+            }
+        }
+
+        private void PerformAnimationFromServer(string animationID, bool isInteracting) {
+            //anim.applyRootMotion = isInteracting;
+            character.anim.SetBool("isInteracting", isInteracting);
+            character.anim.CrossFade(animationID, 0.2f);
+        }
     }
 }

--- a/Assets/Scripts/Common/CharacterAnimatorManager.cs
+++ b/Assets/Scripts/Common/CharacterAnimatorManager.cs
@@ -2,10 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Animations.Rigging;
+using Unity.Netcode;
 
 namespace SoulsLike {
     public class CharacterAnimatorManager : MonoBehaviour {
-        public Animator anim;
+        //public Animator anim;
         protected CharacterManager characterManager;
         protected CharacterStatsManager characterStatsManager;
         public bool canRotate;
@@ -23,43 +24,48 @@ namespace SoulsLike {
 
         // 해당 애니메이션을 실행한다.
         public void PlayTargetAnimation(string targetAnim, bool isInteracting, bool canRotate = false) {
-            anim.applyRootMotion = isInteracting;
-            anim.SetBool("canRotate", canRotate);
-            anim.SetBool("isInteracting", isInteracting);
-            anim.CrossFade(targetAnim, 0.2f);
+            if (characterManager.IsOwner) {
+                characterManager.anim.applyRootMotion = isInteracting;
+                characterManager.anim.SetBool("canRotate", canRotate);
+                characterManager.anim.SetBool("isInteracting", isInteracting);
+                characterManager.anim.CrossFade(targetAnim, 0.2f);
+
+                // 단말에서 애니메이션을 실행하면 내 클라이언트의id 와 애니메이션, 현재 행동정보를 서버에 알림
+                characterManager.characterNetworkManager.NotifyServerOfAnimationServerRpc(NetworkManager.Singleton.LocalClientId, targetAnim, isInteracting);
+            }
         }
 
         // 애니메이션의 회전을 따라감
         public void PlayTargetAnimationWithRootRotation(string targetAnim, bool isInteracting) {
-            anim.applyRootMotion = isInteracting;
-            anim.SetBool("isRotatingWithRootMotion", true);
-            anim.SetBool("isInteracting", isInteracting);
-            anim.CrossFade(targetAnim, 0.2f);
+            characterManager.anim.applyRootMotion = isInteracting;
+            characterManager.anim.SetBool("isRotatingWithRootMotion", true);
+            characterManager.anim.SetBool("isInteracting", isInteracting);
+            characterManager.anim.CrossFade(targetAnim, 0.2f);
         }
 
         #region 애니메이션 이벤트
         public virtual void CanRotate() {
-            anim.SetBool("canRotate", true);
+            characterManager.anim.SetBool("canRotate", true);
         }
 
         public virtual void StopRotation() {
-            anim.SetBool("canRotate", false);
+            characterManager.anim.SetBool("canRotate", false);
         }
 
         public virtual void EnableCombo() {
-            anim.SetBool("canDoCombo", true);
+            characterManager.anim.SetBool("canDoCombo", true);
         }
 
         public virtual void DisableCombo() {
-            anim.SetBool("canDoCombo", false);
+            characterManager.anim.SetBool("canDoCombo", false);
         }
 
         public virtual void EnableIsInvulnerable() {
-            anim.SetBool("isInvulnerable", true);
+            characterManager.anim.SetBool("isInvulnerable", true);
         }
 
         public virtual void DisableIsInvulnerable() {
-            anim.SetBool("isInvulnerable", false);
+            characterManager.anim.SetBool("isInvulnerable", false);
         }
 
         public virtual void EnableIsParrying() {

--- a/Assets/Scripts/Common/CharacterManager.cs
+++ b/Assets/Scripts/Common/CharacterManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Unity.Netcode;
 namespace SoulsLike {
     public class CharacterManager : NetworkBehaviour {
+        public Animator anim;
         CharacterAnimatorManager characterAnimatorManager;
         public CharacterWeaponSlotManager characterWeaponSlotManager;
         public CharacterNetworkManager characterNetworkManager;
@@ -32,7 +33,6 @@ namespace SoulsLike {
         [Header("Movement Flags")]
         public bool isRotatingWithRootMotion;
         public bool canRotate;
-        public bool isSprinting;
         public bool isInAir;
         public bool isGrounded;
         public bool isTwoHandingWeapon;
@@ -46,6 +46,7 @@ namespace SoulsLike {
         public float pendingCriticalDamage;
 
         protected virtual void Awake() {
+            anim = GetComponent<Animator>();
             characterAnimatorManager = GetComponent<CharacterAnimatorManager>();
             characterWeaponSlotManager = GetComponent<CharacterWeaponSlotManager>();
             characterNetworkManager = GetComponent<CharacterNetworkManager>();

--- a/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
+++ b/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
@@ -101,11 +101,11 @@ namespace SoulsLike {
                         // 양잡시 왼쪽손의 무기를 등으로 옮기고, 왼손에 있는 무기는 제거한다.
                         backSlot.LoadWeaponModel(leftHandSlot.currentWeapon);
                         leftHandSlot.UnloadWeaponAndDestroy();
-                        characterAnimatorManager.anim.CrossFade(weaponItem.th_idle, 0.2f);
+                        characterManager.anim.CrossFade(weaponItem.th_idle, 0.2f);
                     } else {
-                        characterAnimatorManager.anim.CrossFade("BothArmsEmpty", 0.2f);
+                        characterManager.anim.CrossFade("BothArmsEmpty", 0.2f);
                         backSlot.UnloadWeaponAndDestroy();
-                        characterAnimatorManager.anim.CrossFade(weaponItem.Right_Hand_Idle, 0.2f);
+                        characterManager.anim.CrossFade(weaponItem.Right_Hand_Idle, 0.2f);
                     }
 
                     // 양잡을 하던 안하던 오른쪽은 변함없음
@@ -117,13 +117,13 @@ namespace SoulsLike {
             } else {
                 weaponItem = unarmedWeapon;
                 if (isLeft) {
-                    characterAnimatorManager.anim.CrossFade("LeftArmEmpty", 0.2f);
+                    characterManager.anim.CrossFade("LeftArmEmpty", 0.2f);
                     characterInventoryManager.leftWeapon = unarmedWeapon;
                     leftHandSlot.currentWeapon = weaponItem;
                     leftHandSlot.LoadWeaponModel(weaponItem);
                     LoadLeftWeaponDamageCollider();
                 } else {
-                    characterAnimatorManager.anim.CrossFade("RightArmEmpty", 0.2f);
+                    characterManager.anim.CrossFade("RightArmEmpty", 0.2f);
                     characterInventoryManager.rightWeapon = unarmedWeapon;
                     rightHandSlot.currentWeapon = weaponItem;
                     rightHandSlot.LoadWeaponModel(weaponItem);

--- a/Assets/Scripts/Player/CameraHandler.cs
+++ b/Assets/Scripts/Player/CameraHandler.cs
@@ -91,7 +91,7 @@ namespace SoulsLike {
          */
         public void HandleCameraRotation(float delta, float mouseXInput, float mouseYInput) {
             // 록온을 하지 않았을 경우
-            if (!inputHandler.lockOnFlag && currentLockOnTarget == null) {
+            if (!playerManager.playerNetworkManager.isLockedOn.Value && currentLockOnTarget == null) {
                 // 시간에 따른 각각의 회전값 변화량을 대입
                 lookAngle += (mouseXInput * lookSpeed) * delta; // 좌우 앵글
                 pivotAngle -= (mouseYInput * pivotSpeed) * delta; // 상하 앵글
@@ -201,7 +201,7 @@ namespace SoulsLike {
                     shortestDistance = distanceFromTarget;
                     nearestLockOnTarget = availableTargets[i];
                 }
-                if (inputHandler.lockOnFlag) { // 록온 상태
+                if (playerManager.playerNetworkManager.isLockedOn.Value) { // 록온 상태
                     // InverseTransformPoint : 객체의 월드좌표를 로컬좌표로 변환
                     // 주변에 락온이 가능한 타겟들의 월드 좌표를 자기 자신의 로컬좌표계로 편입시킨다.
                     Vector3 relativeEnemyPosition = inputHandler.transform.InverseTransformPoint(availableTargets[i].transform.position);

--- a/Assets/Scripts/Player/InputHandler.cs
+++ b/Assets/Scripts/Player/InputHandler.cs
@@ -32,7 +32,6 @@ namespace SoulsLike {
         public bool rollFlag;
         public bool sprintFlag;
         public bool comboFlag;
-        public bool lockOnFlag;
         //public bool inventoryFlag;
 
         public float rollInputTimer; // 다크소울 처럼 tap할 경우 구르고, 계속 누르고있을시 달리도록 하기위한 타이머
@@ -144,6 +143,7 @@ namespace SoulsLike {
             moveAmount = Mathf.Clamp01(Mathf.Abs(horizontal) + Mathf.Abs(vertical));
             mouseX = cameraInput.x;
             mouseY = cameraInput.y;
+            playerManager.playerLocomotion.SetMovementValues(vertical, horizontal, moveAmount);
         }
 
         // 구르기 버튼이 눌리면 회피 Flag의 bool값이 true가 된다.
@@ -228,24 +228,24 @@ namespace SoulsLike {
 
         private void HandleLockOnInput() {
             // 록온 버튼이 눌렸고 아직 록온 상태가 아닌경우
-            if (lockOn_Input && !lockOnFlag) {
+            if (lockOn_Input && !playerManager.playerNetworkManager.isLockedOn.Value) {
 
                 lockOn_Input = !lockOn_Input;
                 cameraHandler.HandleLockOn();
                 if (cameraHandler.nearestLockOnTarget != null) {
                     // 록온 대상 설정
                     cameraHandler.currentLockOnTarget = cameraHandler.nearestLockOnTarget;
-                    lockOnFlag = !lockOnFlag;
+                    playerManager.playerNetworkManager.isLockedOn.Value = !playerManager.playerNetworkManager.isLockedOn.Value;
                 }
             }
             // 록온 버튼이 눌렸고 이미 록온 상태인 경우 => 록온을 풀고 싶은 경우
-            else if (lockOn_Input && lockOnFlag) {
+            else if (lockOn_Input && playerManager.playerNetworkManager.isLockedOn.Value) {
                 lockOn_Input = !lockOn_Input;
-                lockOnFlag = !lockOnFlag;
+                playerManager.playerNetworkManager.isLockedOn.Value = !playerManager.playerNetworkManager.isLockedOn.Value;
                 cameraHandler.ClearLockOnTargets();
             }
 
-            if (lockOnFlag && right_Stick_Left_Input) {
+            if (playerManager.playerNetworkManager.isLockedOn.Value && right_Stick_Left_Input) {
                 right_Stick_Left_Input = false;
                 cameraHandler.HandleLockOn();
                 if (cameraHandler.leftLockTarget != null) {
@@ -253,7 +253,7 @@ namespace SoulsLike {
                 }
             }
 
-            if (lockOnFlag && right_Stick_Right_Input) {
+            if (playerManager.playerNetworkManager.isLockedOn.Value && right_Stick_Right_Input) {
                 right_Stick_Right_Input = false;
                 cameraHandler.HandleLockOn();
                 if (cameraHandler.rightLockTarget != null) {

--- a/Assets/Scripts/Player/Managers/PlayerAnimatorManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerAnimatorManager.cs
@@ -13,7 +13,7 @@ namespace SoulsLike {
         protected override void Awake() {
             base.Awake();
             playerManager = GetComponent<PlayerManager>();
-            anim = GetComponent<Animator>();
+            playerManager.anim = GetComponent<Animator>();
             inputHandler = GetComponentInParent<InputHandler>();
             playerLocomotionManager = GetComponentInParent<PlayerLocomotionManager>();
             vertical = Animator.StringToHash("Vertical");
@@ -44,8 +44,8 @@ namespace SoulsLike {
                 v = 2;
                 h = horizontalMovement;
             }
-            anim.SetFloat(vertical, v, 0.1f, Time.deltaTime);
-            anim.SetFloat(horizontal, h, 0.1f, Time.deltaTime);
+            playerManager.anim.SetFloat(vertical, v, 0.1f, Time.deltaTime);
+            playerManager.anim.SetFloat(horizontal, h, 0.1f, Time.deltaTime);
         }
 
         private void OnAnimatorMove() {
@@ -53,7 +53,7 @@ namespace SoulsLike {
 
             float delta = Time.deltaTime;
             playerLocomotionManager.rigidbody.drag = 0;
-            Vector3 deltaPosition = anim.deltaPosition; // 현재 마지막으로 계산된 프레임에서 아바타의 좌표 변화량
+            Vector3 deltaPosition = playerManager.anim.deltaPosition; // 현재 마지막으로 계산된 프레임에서 아바타의 좌표 변화량
             deltaPosition.y = 0;
             Vector3 velocity = deltaPosition / delta; // 거리의 변화량을 시간으로 나눠 속도를 구한다.
             playerLocomotionManager.rigidbody.velocity = velocity; // Rigidbody의 속도를 설정

--- a/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerCombatManager.cs
@@ -31,7 +31,7 @@ namespace SoulsLike {
         public void HandleWeaponCombo(WeaponItem weapon) {
             if (playerStatsManager.currentStamina <= 0) return;
             if (inputHandler.comboFlag) {
-                playerAnimatorManager.anim.SetBool("canDoCombo", false);
+                playerManager.anim.SetBool("canDoCombo", false);
                 if (lastAttack == weapon.OH_Light_Attack_1) {
                     //Debug.Log("콤보 공격 실행");
                     playerAnimatorManager.PlayTargetAnimation(weapon.OH_Light_Attack_2, true);
@@ -98,7 +98,7 @@ namespace SoulsLike {
             } else {
                 if (playerManager.isInteracting) return;
                 if (playerManager.canDoCombo) return;
-                playerAnimatorManager.anim.SetBool("isUsingRightHand", true);
+                playerManager.anim.SetBool("isUsingRightHand", true);
                 HandleLightAttack(playerInventoryManager.rightWeapon);
             }
         }
@@ -140,7 +140,7 @@ namespace SoulsLike {
         // Animation Event에서 호출하기 위한 함수
         private void SuccessfullyCastSpell() {
             playerInventoryManager.currentSpell.SuccessfullyCastSpell(playerAnimatorManager, playerStatsManager, cameraHandler, playerWeaponSlotManager);
-            playerAnimatorManager.anim.SetBool("isFiringSpell", true);
+            playerManager.anim.SetBool("isFiringSpell", true);
             //Debug.Log("투척 이벤트");
         }
 

--- a/Assets/Scripts/Player/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerManager.cs
@@ -10,15 +10,17 @@ using Unity.Netcode;
 namespace SoulsLike {
     public class PlayerManager : CharacterManager {
         public InputHandler inputHandler;
-        Animator anim;
+        //public Animator anim;
         public GameObject interactableUIGameObject; // 상호작용 메세지 (문 열기, 레버 내리기 등) : InteractionPopUp
         public GameObject itemInteractableGameObject; // 아이템 획득 메세지 : ItemPopup
         public GameObject dialogUI; // NPC의 대사를 출력할 창
         public Transform leftFoot, rightFoot;
         public LadderEndPositionDetection ladderEndPositionDetector;
+        public PlayerNetworkManager playerNetworkManager;
 
         // 다크소울 시리즈에서는 대화 도중 행동이 가능하므로 isInteracting 과 분리
         public bool isInConversation;
+        
         public bool isJumping = false;
         public bool rightFootUp;
         public bool isLadderTop;
@@ -27,12 +29,12 @@ namespace SoulsLike {
         private readonly float turnPageTime = 10f;
         private int currentPageIndex;
 
-        PlayerAnimatorManager playerAnimatorManager;
+        public PlayerAnimatorManager playerAnimatorManager;
         PlayerStatsManager playerStatsManager;
         PlayerEffectsManager playerEffectsManager;
-        PlayerLocomotionManager playerLocomotion;
+        public PlayerLocomotionManager playerLocomotion;
         public NPCScript[] currentDialog;
-        CameraHandler cameraHandler;
+        public CameraHandler cameraHandler;
 
         [SerializeField]
         InteractableUI interactableUI; // 상호작용때 나타나는 메세지 창
@@ -40,6 +42,8 @@ namespace SoulsLike {
 
         protected override void Awake() {
             base.Awake();
+
+            playerNetworkManager = GetComponent<PlayerNetworkManager>();
             ladderEndPositionDetector = GetComponentInChildren<LadderEndPositionDetection>();
             if (ladderEndPositionDetector != null) ladderEndPositionDetector.transform.gameObject.SetActive(false);
             playerAnimatorManager = GetComponent<PlayerAnimatorManager>();
@@ -124,6 +128,7 @@ namespace SoulsLike {
         public Transform interactionTargetPosition;
         protected override void FixedUpdate() {
             base.FixedUpdate();
+            if (!IsOwner) return;
             float delta = Time.fixedDeltaTime;
 
             // Rigidbody를 통해 처리되는 움직임은 FixedUpdate에서 처리되는것이 좋음
@@ -160,7 +165,7 @@ namespace SoulsLike {
             // 아바타가 움직인 좌표의 변화량을 측정하고 애니메이션 실행된 시간으로 나눠 속도를 구한후 플레이어의 rigidbody 에 대입하여 자연스럽게보이도록 속도를 대입함
             // 애니메이션의 전이가 모든 애니메이션의 마지막 프레임 이후 실행되는 거라면 상관없지만 자연스러운 전이를 위해 대부분 그러지 않으므로 Rigidbody의 velocity 가 0이 되었다가 마지막 프레임에서
             // 다시 OnAnimatorMove 메서드가 호출되면서 Rigidbody 의 velocity 값이 변화하는 듯
-            if ((isClimbing || isAtBonfire) && playerAnimatorManager.anim.GetCurrentAnimatorClipInfoCount(5) == 0) { // 한 프레임마다 5번 레이어의 현재 애니메이션이 Empty 라면 rigidbody 의 속도를 0으로 만듬
+            if ((isClimbing || isAtBonfire) && anim.GetCurrentAnimatorClipInfoCount(5) == 0) { // 한 프레임마다 5번 레이어의 현재 애니메이션이 Empty 라면 rigidbody 의 속도를 0으로 만듬
                 playerLocomotion.rigidbody.velocity = Vector3.zero;
             }
 

--- a/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
@@ -86,7 +86,7 @@ namespace SoulsLike {
             GameObject activeBombModel = Instantiate(fireBombItem.liveBombModel, rightHandSlot.transform.position, cameraHandler.cameraPivotTransform.rotation);
             // 화염병의 회전값은 카메라의 회전값과 맞춰 플레이어가 바라보는 방향으로 날아가게 한다
             activeBombModel.transform.rotation = Quaternion.Euler(cameraHandler.cameraPivotTransform.eulerAngles.x, playerManager.lockOnTransform.eulerAngles.y, 0);
-            
+
             // 화염병 속도 설정
             BombDamageCollider damageCollider = activeBombModel.GetComponentInChildren<BombDamageCollider>();
             damageCollider.contactDamage = fireBombItem.baseDamage;
@@ -94,17 +94,19 @@ namespace SoulsLike {
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.forward * fireBombItem.forwardVelocity);
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.up * fireBombItem.upwardVelocity);
             damageCollider.teamIDNumber = playerStatsManager.teamIDNumber; // 피아식별을 위한 팀ID 설정
-            // LoadWeaponSlot(playerInventory.rightWeapon, false);
-            
+                                                                           // LoadWeaponSlot(playerInventory.rightWeapon, false);
+
         }
 
         #region Handle Weapon's Stamina Drainage
         public void DrainStaminaLightAttack() {
-            playerStatsManager.TakeStaminaDamage(Mathf.RoundToInt(attackingWeapon.baseStamina * attackingWeapon.lightAttackMultiplier));
+            if (playerManager.IsOwner)
+                playerStatsManager.TakeStaminaDamage(Mathf.RoundToInt(attackingWeapon.baseStamina * attackingWeapon.lightAttackMultiplier));
         }
 
         public void DrainStaminaHeavyAttack() {
-            playerStatsManager.TakeStaminaDamage(Mathf.RoundToInt(attackingWeapon.baseStamina * attackingWeapon.heavyAttackMultiplier));
+            if (playerManager.IsOwner)
+                playerStatsManager.TakeStaminaDamage(Mathf.RoundToInt(attackingWeapon.baseStamina * attackingWeapon.heavyAttackMultiplier));
         }
         #endregion
     }

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -20,7 +20,7 @@ PhysicsManager:
   m_ContactsGeneration: 1
   m_LayerCollisionMatrix: 7fffffff7ffbffff7ffbffffffffffff7ffbffff7ffbffffffffffff48c1fffffffbffff7fbbffff49bcffff7ff7ffff7fffffff7ffffffffff9ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   m_AutoSimulation: 1
-  m_AutoSyncTransforms: 0
+  m_AutoSyncTransforms: 1
   m_ReuseCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
   m_ClothGravity: {x: 0, y: -9.81, z: 0}


### PR DESCRIPTION
- 다른 클라이언트에서 내 오브젝트의 애니메이션 재생
- 기본적으로는 게임내의 어떤 다른 클라이언트가 내 게임의 특정 스크립트에서 특정 변수가 변경되는것을 알아낼 방법이 없음
- 하지만 네트워크 변수는 한쪽에서 변경될 때마다 모든 클라이언트들에 대해 변경된다
- 현재 BlendTree를 이용해서 입력에 따라 이동 애니메이션을 제어하는 상태
- 하지만 록온을 한 상태와 질주상태의 경우는 입력장치로 부터 같은 입력값을 받더라도 다른 애니메이션을 사용
- 따라서 SprintFlag 와 LockOnFlag 를 네트워크 변수로 만들어서 사용한다.

- 단말에서 내 오브젝트로 애니메이션을 수행한다면, 서버에 내 클라이언트id 와 애니메이션, 행동 정보를 서버에 알림
- 서버는 연결된 모든 클라이언트에게 지정된 오브젝트가 애니메이션을 수행하도록 클라이언트id와 애니메이션, 행동 정보를 넘김
- 클라이언트에서는 다시 자신의 클라이언트 id와 대조하여 다른경우에만 넘겨받은 애니메이션과 행동정보를 사용

# CharacterNetworkManager
- 플레이어의 질주/록온 상태를 나타내기위한 bool 변수
- 단말에서 서버로 클라이언트id, 애니메이션, 행동 정보를 넘겨주기 위한 메소드
- 클라이언트로부터 넘겨받은 정보를 통해 연결된 모든 클라이언트에게 지정된 오브젝트가 애니메이션을 수행할 수 있게끔 클라이언트id, 애니메이션, 행동정보를 넘겨주기 위한 메소드
- 서버로부터 넘겨받은 애니메이션, 행동정보를 이용해 오브젝트의 애니메이션을 재생할 메소드

# InputHandler, CameraHandler
- SprintFlag 와 LockOnFlag변수 호출방식 변경 

## InputHandler
- 키보드 입력으로부터 이동 관련 변수를 대입할때 다른 클라이언트에서 오브젝트 이동 애니메이션을 제어하기 위한 애니메이션 변수들에 입력값을 할당

# CharacterAnimatorManager
- 오브젝트의 애니메이션을 재생할때, 서버에게 클라이언트, 애니메이션, 행동 정보를 넘겨줌

# PlayerLocomotionManager
- 다른 클라이언트에서 오브젝트의 이동 애니메이션을 제어하기 위한 애니메이션 변수들
- 오브젝트의 주인이라면 네트워크 변수에 내 오브젝트의 수직,수평 이동값과 총량 대입
- 오브젝트의 주인이 다른 클라이언트라면 네트워크 변수로부터 값을 받아와 대입
- 블렌드트리에도 반영

# PlayerWeaponSlotManager
- 다른 클라이언트의 오브젝트가 무기를 휘둘렀을때 다른 오브젝트들의 스테미너가 깎이지 않도록 주인인지 검사