### PR TITLE
세이브

### DIFF
--- a/Assets/Scenes/WorldScene_01.unity
+++ b/Assets/Scenes/WorldScene_01.unity
@@ -2474,7 +2474,7 @@ Transform:
   - {fileID: 1386618227}
   - {fileID: 455943246}
   m_Father: {fileID: 1804018008}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &213450622
 GameObject:
@@ -11339,7 +11339,7 @@ GameObject:
   m_Component:
   - component: {fileID: 531349621}
   m_Layer: 0
-  m_Name: Item
+  m_Name: Item1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -13103,7 +13103,7 @@ Transform:
   - {fileID: 558979093225009292}
   - {fileID: 780480377}
   m_Father: {fileID: 1804018008}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &696046208
 GameObject:
@@ -30117,7 +30117,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1211580253}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.5, y: 0, z: -18.99}
+  m_LocalPosition: {x: -3.5, y: -1, z: -18.99}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -52391,6 +52391,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 531349621}
+  - {fileID: 1986446496}
   - {fileID: 693988326}
   - {fileID: 211704102}
   m_Father: {fileID: 0}
@@ -55241,6 +55242,38 @@ Transform:
   m_Father: {fileID: 230041441}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1986446495
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1986446496}
+  m_Layer: 0
+  m_Name: item2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1986446496
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1986446495}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2004443219}
+  m_Father: {fileID: 1804018008}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1987981444
 GameObject:
   m_ObjectHideFlags: 0
@@ -55352,6 +55385,88 @@ Transform:
   m_Father: {fileID: 1322492954}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2004443218
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1986446496}
+    m_Modifications:
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: item
+      value: 
+      objectReference: {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: weapon
+      value: 
+      objectReference: {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: itemPickUpID
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: itemPickUpId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: interactableText
+      value: "\uC544\uC774\uD15C\uC744 \uC90D\uB294\uB2E4"
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -18.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843559, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: m_Name
+      value: Weapon Pick Up
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+--- !u!4 &2004443219 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+  m_PrefabInstance: {fileID: 2004443218}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2005981820
 GameObject:
   m_ObjectHideFlags: 0
@@ -62976,6 +63091,14 @@ PrefabInstance:
       propertyPath: weapon
       value: 
       objectReference: {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: itemPickUpID
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
+      propertyPath: itemPickUpId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6078572700425843552, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
       propertyPath: interactableText
       value: "\uC544\uC774\uD15C\uC744 \uC90D\uB294\uB2E4"

--- a/Assets/Scripts/Items/Interactables/Interactable.cs
+++ b/Assets/Scripts/Items/Interactables/Interactable.cs
@@ -12,6 +12,11 @@ namespace SoulsLike {
             Gizmos.DrawWireSphere(transform.position, radius);
         }
 
+        protected virtual void Awake() {
+        }
+
+        protected virtual void Start() {
+        }
 
         // 다른 클래스에서 사용할때 override해서 사용할 수 있도록 virtual 형으로 만든다.
         public virtual void Interact(PlayerManager playerManager) {

--- a/Assets/Scripts/Items/ItemPickUp.cs
+++ b/Assets/Scripts/Items/ItemPickUp.cs
@@ -5,10 +5,50 @@ using UnityEngine.UI;
 
 namespace SoulsLike {
     public class ItemPickUp : Interactable {
-        //public WeaponItem weapon;
+        [Header("Item Information")]
+        [SerializeField] int itemPickUpID; // 월드에 스폰될 아이템들의 식별 번호
+        [SerializeField] bool hasBeenLooted; // 플레이어가 회수했는지 안했는지 여부
         public Item item;
+
+        protected override void Awake() {
+            base.Awake();
+        }
+
+        protected override void Start() {
+            base.Start();
+
+            // 만약 현재 캐릭터 세이브 데이터의
+            // 월드에서 회수한 아이템 목록에 이 아이템이 없다면
+            // 이 아이템을 회수한 적이 없는 것
+            // 따라서 회수 되지 않았다고 기록해야 함
+            if (!WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld.ContainsKey(itemPickUpID)) {
+                WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld.Add(itemPickUpID, false);
+            }
+
+            hasBeenLooted = WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld[itemPickUpID];
+
+            if (hasBeenLooted) {
+                gameObject.SetActive(false);
+            }
+        }
+        
         public override void Interact(PlayerManager playerManager) {
             base.Interact(playerManager); // 부모의 Interact함수를 호출한다.
+
+            // 캐릭터 데이터에 이 아이템이 플레이어에게 회수되었는지를 알려 만약 이미 회수된 아이템이라면 다시 월드에 스폰되지 않도록 함
+
+            // 만약 현재 캐릭터 세이브 데이터의 게임 월드에서 회수한 아이템 목록에 이 스폰 아이템의 식별 번호가 존재한다면
+            if (WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld.ContainsKey(itemPickUpID)) {
+                // 해당 식별번호를 key 값으로 하는 항목을 제거
+                WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld.Remove(itemPickUpID);
+            }
+
+            // 해당 식별번호를 key 값으로 하는 항목의 value에 true 를 입력하여 다시 추가
+            WorldSaveGameManager.instance.currentCharacterSaveData.itemsInWorld.Add(itemPickUpID, true);
+
+            hasBeenLooted = true;
+
+            // 플레이어의 인벤토리에 아이템을 전달한다
             PickUpItem(playerManager);
         }
         

--- a/Assets/Scripts/Save Game/CharacterSaveData.cs
+++ b/Assets/Scripts/Save Game/CharacterSaveData.cs
@@ -21,5 +21,15 @@ namespace SoulsLike {
         public float xPosition;
         public float yPosition;
         public float zPosition;
+
+        [Header("Items Looted From World")]
+        // 월드로부터 루팅 가능한 아이템들의 목록인건지 내가 월드로부터 루팅 한 아이템의 목록인건지 애매
+        // int 형 변수는 월드에 스폰된 아이템의 식별 번호
+        // bool 변수는 플레이어가 아이템을 회수했는지 여부
+        public SerializableDictionary<int, bool> itemsInWorld;
+
+        public CharacterSaveData() {
+            itemsInWorld = new SerializableDictionary<int, bool>();
+        }
     }
 }

--- a/Assets/SerializableDictionary.cs
+++ b/Assets/SerializableDictionary.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+namespace SoulsLike {
+    [Serializable]
+    public class SerializableDictionary<Tkey, TValue> : Dictionary<TKey, TValue> , ISerializationCallbackReceiver{
+        [SerializeField] private List<TKey> keys = new List<TKey>();
+        [SerializeField] private List<TValue> values = new List<TValue>();
+
+        // 직렬화 바로 전에 호출
+        // 딕셔너리를 리스트로 저장
+        public void OnBeforeSerialize() {
+            keys.Clear();
+            values.Clear();
+
+            foreach(KeyValuePair<TKey, TValue> pair in this){
+                keys.Add(pair.Key);
+                values.Add(pair.Value);
+            }
+        }
+
+        // 직렬화 바로 이후에 호출
+        // 리스트로부터 딕셔너리를 로드
+        public void OnAfterDeserialize() {
+            Clear();
+            if (keys.Count != values.Count) {
+                Debug.LogError("딕셔너리를 역직렬화 하려고 시도했으나, key 값들의 개수가 value 값들의 개수와 맞지 않습니다");
+            }
+
+            for (int i = 0; i < keys.Count; i++) {
+                Add(keys[i], values[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 월드에 스폰된 아이템들의 상태 저장
- 월드에 스폰된 아이템들은 두가지의 식별 변수를 사용한다
- 월드에 스폰된 아이템들을 서로 구분하기 위한 식별 번호와 플레이어가 해당 아이템을 이미 회수했는지 안했는지의 여부를 나타낼 식별 bool 변수를 가짐

# SerializableDictionary
- 일반화 컬렉션 사용
- 이 클래스는 딕셔너리 클래스와, ISerializationCallbackReceiver 인터페이스를 상속
- key, value 값에 사용할 데이터들을 list 로 가지고 있으며 직렬화 하기 바로 전에 key 값들과 value 값들을 리스트에 기록
- 역직렬화 바로 이후에 만약 key 값들의 개수와 value 값들의 개수가 다르다면 에러 메시지를 출력하고 현재 key 값의 수 만큼 딕셔너리에 추가한다.

# CharacterSaveData
- 월드로 부터 회수할 수 있는 아이템들의 목록을 기록할 딕셔너리를 가짐
- 딕셔너리의 모든 pair 항목들의 value 값을 통해 해당 아이템을 플레이어가 회수했는지 안했는지 알수 있음

# ItemPickUp
- 씬이 로드되면 해당 씬의 스폰 아이템들은 현재 캐릭터의 세이브 데이터에서 자기 자신의 식별번호 pair 항목의 value 값이 false 인지 검사
- 만약 value 값이 false 면, 플레이어는 해당 아이템을 회수한 적이 없는 것이므로 pair의 bool 값을 false로 기록한후 딕셔너리에 추가
- 만약 이미 회수된 아이템이라면 비활성화 한다.
- 상호작용시 딕셔너리에서 해당 아이템의 식별번호를 찾은후 항목을 삭제, pair의 bool 값을 true로 해서 다시 딕셔너리에 추가한다.