### PR TITLE
Netcode

### DIFF
--- a/Assets/Art/Animations/AnimatorControllers/Humanoid AI.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid AI.controller
@@ -489,7 +489,8 @@ AnimatorState:
   m_Name: Falling
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -4352357110703915805}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -893,6 +894,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-4352357110703915805
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isGrounded
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7614952085033397074}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.765625
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-4304708652415388249
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1850,91 +1876,103 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInteracting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canDoCombo
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: canRotate
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingRightHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isUsingLeftHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isInvulnerable
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isBlocking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isFiringSpell
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isRotatingWithRootMotion
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isPhaseShifting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isGrabbed
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: isGrounded
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: inAirTimer
+    m_Type: 1
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -2529,6 +2567,34 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &3461745747518032564
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isGrounded
+    m_EventTreshold: 0
+  - m_ConditionMode: 3
+    m_ConditionEvent: inAirTimer
+    m_EventTreshold: 0.2
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6404699382290321208}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &3484913696267326862
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -2736,7 +2802,8 @@ AnimatorState:
   m_Name: Empty
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 3461745747518032564}
   m_StateMachineBehaviours:
   - {fileID: -7608436321072077826}
   m_Position: {x: 50, y: 50, z: 0}
@@ -3062,10 +3129,10 @@ AnimatorStateMachine:
     m_Position: {x: 350, y: -160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6404699382290321208}
-    m_Position: {x: -120, y: -270, z: 0}
+    m_Position: {x: -160, y: -200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7614952085033397074}
-    m_Position: {x: 100, y: -160, z: 0}
+    m_Position: {x: -160, y: -130, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4376060953521737155}
     m_Position: {x: 100, y: -110, z: 0}
@@ -3098,7 +3165,7 @@ AnimatorStateMachine:
     m_Position: {x: 90, y: -320, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1139302450532381031}
-    m_Position: {x: 90, y: -270, z: 0}
+    m_Position: {x: -160, y: -270, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2835223261342340991}
     m_Position: {x: 580, y: -20, z: 0}
@@ -3405,8 +3472,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: isInAir
+  - m_ConditionMode: 2
+    m_ConditionEvent: isGrounded
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6404699382290321208}

--- a/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
+++ b/Assets/Art/Animations/AnimatorControllers/Humanoid.controller
@@ -1411,7 +1411,7 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   - m_ConditionMode: 3
     m_ConditionEvent: inAirTimer
-    m_EventTreshold: 0.1
+    m_EventTreshold: 0.2
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6404699382290321208}
   m_Solo: 0
@@ -2322,115 +2322,115 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isInteracting
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: canDoCombo
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: canRotate
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isUsingRightHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isUsingLeftHand
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isInvulnerable
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isBlocking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFiringSpell
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isRotatingWithRootMotion
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isClimbing
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: rightFootUp
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isLadderTop
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAtBonefire
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isGrounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: inAirTimer
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -3880,16 +3880,16 @@ AnimatorStateMachine:
     m_Position: {x: 350, y: -160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6404699382290321208}
-    m_Position: {x: -130, y: -160, z: 0}
+    m_Position: {x: -30, y: -170, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7614952085033397074}
-    m_Position: {x: -130, y: -90, z: 0}
+    m_Position: {x: -30, y: -70, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4376060953521737155}
-    m_Position: {x: 100, y: -70, z: 0}
+    m_Position: {x: 70, y: 30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1110617932129752830}
-    m_Position: {x: 100, y: -20, z: 0}
+    m_Position: {x: 70, y: 80, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8103759454790931140}
     m_Position: {x: 580, y: -170, z: 0}
@@ -3901,10 +3901,10 @@ AnimatorStateMachine:
     m_Position: {x: 580, y: -70, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5271245649354770097}
-    m_Position: {x: 100, y: -460, z: 0}
+    m_Position: {x: 50, y: -570, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 2413881424679774082}
-    m_Position: {x: -130, y: -220, z: 0}
+    m_Position: {x: -330, y: -480, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8471091968650047159}
     m_Position: {x: 580, y: -270, z: 0}
@@ -3913,7 +3913,7 @@ AnimatorStateMachine:
     m_Position: {x: 580, y: -220, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1139302450532381031}
-    m_Position: {x: 100, y: -210, z: 0}
+    m_Position: {x: -30, y: -270, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2835223261342340991}
     m_Position: {x: 580, y: -20, z: 0}
@@ -3922,10 +3922,10 @@ AnimatorStateMachine:
     m_Position: {x: 580, y: 30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 805918016173055142}
-    m_Position: {x: 100, y: 80, z: 0}
+    m_Position: {x: 70, y: 180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8756932603905847214}
-    m_Position: {x: 100, y: 30, z: 0}
+    m_Position: {x: 70, y: 130, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4112469286270638627}
     m_Position: {x: 580, y: -320, z: 0}
@@ -3958,16 +3958,16 @@ AnimatorStateMachine:
     m_Position: {x: 760, y: 200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1154965276067657945}
-    m_Position: {x: 100, y: -310, z: 0}
+    m_Position: {x: 50, y: -420, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1607487726440668554}
     m_Position: {x: 390, y: -580, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 221038576124829532}
-    m_Position: {x: 100, y: 180, z: 0}
+    m_Position: {x: 70, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1117597461007863893}
-    m_Position: {x: 100, y: 130, z: 0}
+    m_Position: {x: 70, y: 230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1712414704290404051}
     m_Position: {x: 580, y: -470, z: 0}
@@ -3979,7 +3979,7 @@ AnimatorStateMachine:
     m_Position: {x: 740, y: -590, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -345012797296449922}
-    m_Position: {x: 100, y: 230, z: 0}
+    m_Position: {x: 70, y: 330, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -357349871084431477}
     m_Position: {x: 1010, y: -320, z: 0}
@@ -4000,46 +4000,46 @@ AnimatorStateMachine:
     m_Position: {x: 1080, y: 20, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1429269301258980880}
-    m_Position: {x: -120, y: 80, z: 0}
+    m_Position: {x: -150, y: 180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4019211786880342137}
-    m_Position: {x: -120, y: 130, z: 0}
+    m_Position: {x: -150, y: 230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 888585881097028915}
-    m_Position: {x: -120, y: 30, z: 0}
+    m_Position: {x: -150, y: 130, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4907403322708706891}
-    m_Position: {x: -120, y: -20, z: 0}
+    m_Position: {x: -150, y: 80, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7789865765342442340}
-    m_Position: {x: -120, y: 180, z: 0}
+    m_Position: {x: -150, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2774963352630148945}
-    m_Position: {x: -120, y: 230, z: 0}
+    m_Position: {x: -150, y: 330, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 9124114481127011165}
-    m_Position: {x: -130, y: -270, z: 0}
+    m_Position: {x: -330, y: -530, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6722660712525862761}
-    m_Position: {x: 100, y: -410, z: 0}
+    m_Position: {x: 50, y: -520, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7439113800743907397}
-    m_Position: {x: 100, y: -560, z: 0}
+    m_Position: {x: 50, y: -670, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1942238554320218794}
-    m_Position: {x: 100, y: -510, z: 0}
+    m_Position: {x: 50, y: -620, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2367785046502550338}
-    m_Position: {x: 100, y: -260, z: 0}
+    m_Position: {x: 50, y: -370, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 54541160252583401}
-    m_Position: {x: 100, y: -360, z: 0}
+    m_Position: {x: 50, y: -470, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -5245821381762361001}
-    m_Position: {x: 100, y: 280, z: 0}
+    m_Position: {x: 70, y: 380, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -5001627441906276077}
-    m_Position: {x: 100, y: 330, z: 0}
+    m_Position: {x: 70, y: 430, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6201157149645530964}
     m_Position: {x: 310, y: 280, z: 0}

--- a/Assets/Data/Items/Weapons/Axe.asset
+++ b/Assets/Data/Items/Weapons/Axe.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: f8a0997c30b33fd42998800317e977d3, type: 3}
   itemName: "\uC1E0\uB3C4\uB07C"
   flavorText: "\uD3C9\uBC94\uD55C \uC1E0\uB3C4\uB07C."
-  itemID: 4
+  itemID: 1
   modelPrefab: {fileID: 6286975738734905360, guid: cdddfa5d5ff0e6149bce57e9f379242c, type: 3}
   isUnarmed: 0
   physicalDamage: 25

--- a/Assets/Data/Items/Weapons/Boss Dagger.asset
+++ b/Assets/Data/Items/Weapons/Boss Dagger.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 0}
   itemName: "\uB3C4\uC801\uC758 \uB2E8\uAC80"
   flavorText: 
-  itemID: 9
+  itemID: 2
   modelPrefab: {fileID: 6540428604315627310, guid: a3b44e40c2bc8124594baf78236c0338, type: 3}
   isUnarmed: 0
   physicalDamage: 25

--- a/Assets/Data/Items/Weapons/Dagger.asset
+++ b/Assets/Data/Items/Weapons/Dagger.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 0}
   itemName: "\uB2E8\uAC80"
   flavorText: 
-  itemID: 5
+  itemID: 3
   modelPrefab: {fileID: 15128329762310512, guid: 21375eb3e670c844797314db17dd7120, type: 3}
   isUnarmed: 0
   physicalDamage: 25

--- a/Assets/Data/Items/Weapons/GreatSword.asset
+++ b/Assets/Data/Items/Weapons/GreatSword.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: e6aa180725acf9446a08de1a76ab3c31, type: 3}
   itemName: "\uB300\uAC80"
   flavorText: 
-  itemID: 6
+  itemID: 4
   modelPrefab: {fileID: 5203056566384583489, guid: f68df1f419c5efc46afa99f4f4fc9eb6, type: 3}
   isUnarmed: 0
   physicalDamage: 50

--- a/Assets/Data/Items/Weapons/Pyromancy Flame.asset
+++ b/Assets/Data/Items/Weapons/Pyromancy Flame.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: 32d521d57b496f74bbd28290847f8e58, type: 3}
   itemName: "\uC8FC\uC220\uC758 \uBD88\uAF43"
   flavorText: 
-  itemID: 7
+  itemID: 5
   modelPrefab: {fileID: 1629452786845666990, guid: 4af8935bfffce6745a92b499db51bea7, type: 3}
   isUnarmed: 0
   physicalDamage: 25

--- a/Assets/Data/Items/Weapons/Shield_L.asset
+++ b/Assets/Data/Items/Weapons/Shield_L.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: 7cdfac7a7246d274c8b983fd664158c9, type: 3}
   itemName: "\uBC29\uD328"
   flavorText: "\uD2BC\uD2BC\uD55C \uCCA0\uC81C \uBC29\uD328"
-  itemID: 2
+  itemID: 6
   modelPrefab: {fileID: 5203412457603426678, guid: e105b7be8d1d33549bb3605cb4b61673, type: 3}
   isUnarmed: 0
   physicalDamage: 10

--- a/Assets/Data/Items/Weapons/Shield_R.asset
+++ b/Assets/Data/Items/Weapons/Shield_R.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: 7cdfac7a7246d274c8b983fd664158c9, type: 3}
   itemName: "\uBC29\uD328"
   flavorText: "\uD2BC\uD2BC\uD55C \uCCA0\uC81C \uBC29\uD328"
-  itemID: 1
+  itemID: 7
   modelPrefab: {fileID: 5203412457603426678, guid: 8fa242bfc5c8954418d4765807effcbf, type: 3}
   isUnarmed: 0
   physicalDamage: 10

--- a/Assets/Data/Items/Weapons/Sword.asset
+++ b/Assets/Data/Items/Weapons/Sword.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: 3d5de3033771a224ba4f9b2409012617, type: 3}
   itemName: "\uB871\uC18C\uB4DC"
   flavorText: "\uCCA0\uC81C \uC9C1\uAC80"
-  itemID: 3
+  itemID: 8
   modelPrefab: {fileID: 9172609376268836479, guid: d5fb25c7ffd5e5e408d12b0dc639213b, type: 3}
   isUnarmed: 0
   physicalDamage: 25

--- a/Assets/Data/Items/Weapons/Talisman.asset
+++ b/Assets/Data/Items/Weapons/Talisman.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: 92c6fbc1833686244a56633c96eadc6f, type: 3}
   itemName: "\uD0C8\uB9AC\uC2A4\uB9CC"
   flavorText: 
-  itemID: 8
+  itemID: 9
   modelPrefab: {fileID: 3369392048246929232, guid: d04a868860d690241a3c165b2feac5a4, type: 3}
   isUnarmed: 0
   physicalDamage: 1

--- a/Assets/Data/Items/Weapons/Unarmed.asset
+++ b/Assets/Data/Items/Weapons/Unarmed.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   itemIcon: {fileID: 21300000, guid: ab2c0effa4522104dbdb381ab0b16a7b, type: 3}
   itemName: "\uBE44\uBB34\uC7A5"
   flavorText: 
+  itemID: -1
   modelPrefab: {fileID: 4095508314949055592, guid: 18121f172404aa7479f3e1867d451eef, type: 3}
   isUnarmed: 1
   physicalDamage: 5

--- a/Assets/Prefabs/Camera.prefab
+++ b/Assets/Prefabs/Camera.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   inputHandler: {fileID: 0}
   playerManager: {fileID: 0}
   lookSpeed: 150
-  groundedFollowSpeed: 50
+  groundedFollowSpeed: 30
   inAirFollowSpeed: 20
   pivotSpeed: 150
   minimumPivot: -35

--- a/Assets/Prefabs/Enemy_CC.prefab
+++ b/Assets/Prefabs/Enemy_CC.prefab
@@ -1295,7 +1295,6 @@ MonoBehaviour:
   isGrabbed: 0
   isRotatingWithRootMotion: 0
   canRotate: 0
-  isInAir: 0
   isGrounded: 0
   isTwoHandingWeapon: 0
   isClimbing: 0
@@ -1305,7 +1304,6 @@ MonoBehaviour:
   currentState: {fileID: 634820070}
   currentTarget: {fileID: 0}
   navMeshAgent: {fileID: 0}
-  enemyRigidbody: {fileID: 0}
   rotationSpeed: 15
   maximumAggroRadius: 2
   detectionRadius: 10
@@ -1330,16 +1328,13 @@ MonoBehaviour:
   moveDirection: {x: 0, y: 0, z: 0}
   groundLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 258
   inAirTimer: 0
   yVelocity: {x: 0, y: 0, z: 0}
   groundedYVelocity: -20
-  fallStartYVelocity: -7
+  fallStartYVelocity: -4
   gravityForce: -25
-  groundCheckSphereRadius: 0
-  detectionLayer:
-    serializedVersion: 2
-    m_Bits: 0
+  groundCheckSphereRadius: 0.2
 --- !u!114 &2674730931720195348
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1450,12 +1445,12 @@ CharacterController:
   m_Enabled: 1
   serializedVersion: 2
   m_Height: 2
-  m_Radius: 0.5
+  m_Radius: 0.2
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 0.87, z: 0}
 --- !u!1 &1253894068147768686
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/PlayerUI.prefab
+++ b/Assets/Prefabs/PlayerUI.prefab
@@ -7313,7 +7313,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3374036298944812180}
   m_Layer: 5
-  m_Name: Stat Bar
+  m_Name: Stat Bars
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -13812,6 +13812,7 @@ GameObject:
   - component: {fileID: 4110212349623131902}
   - component: {fileID: 4110212349623131903}
   - component: {fileID: 7583938588239694952}
+  - component: {fileID: 1793335852}
   m_Layer: 5
   m_Name: PlayerUI
   m_TagString: Untagged
@@ -13874,10 +13875,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -13914,9 +13915,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: edd676ff440b5ba4d869b11d0ecb4ae0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  player: {fileID: 0}
   playerInventory: {fileID: 0}
   playerStatsManager: {fileID: 0}
   equipmentWindowUI: {fileID: 1459538715}
+  soulCount: {fileID: 3374036298737047956}
+  healthBar: {fileID: 4110212348090737349}
+  staminaBar: {fileID: 5779780424125324873}
+  focusBar: {fileID: 546269266459459763}
+  poisonBuildUpBar: {fileID: 3374036299897520938}
+  poisonAmountBar: {fileID: 3374036299143256813}
   hudWindow: {fileID: 5265302459628239622}
   selectMenuWindow: {fileID: 1577174782}
   equipmentScreenWindow: {fileID: 270672225}
@@ -13940,6 +13948,18 @@ MonoBehaviour:
   consumableInventorySlotsParent: {fileID: 3374036299906003158}
   weaponInventorySlots: []
   consumableInventorySlots: []
+--- !u!225 &1793335852
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4110212349623131900}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &4110212349656911954
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/World Item Database.prefab
+++ b/Assets/Prefabs/World Item Database.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5166077209182145812}
+  - component: {fileID: 6345208232444783560}
   m_Layer: 0
   m_Name: World Item Database
   m_TagString: Untagged
@@ -31,3 +32,36 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6345208232444783560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888462903555093480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e670bf20d44966841815b33940e52e9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  unarmedWeapon: {fileID: 11400000, guid: 1988c26deec11134fbe97c2b980264fb, type: 2}
+  allItems: []
+  weaponItems:
+  - {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
+  - {fileID: 11400000, guid: 311163681efcd6b428e73397bf9f5144, type: 2}
+  - {fileID: 11400000, guid: b61b5ecad97f8f842857785ee3715272, type: 2}
+  - {fileID: 11400000, guid: 32f44fc45c1141b4a8638938b109e01c, type: 2}
+  - {fileID: 11400000, guid: 8b308fd9bb65d8e44b55ed88c725a975, type: 2}
+  - {fileID: 11400000, guid: abb7cab4b5daf3149b10e080111dff8d, type: 2}
+  - {fileID: 11400000, guid: 5b39c446a406e4c41b9b3b2a233306f3, type: 2}
+  - {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
+  - {fileID: 11400000, guid: eee116bfe66806e45ab2bc14d3a0c8e9, type: 2}
+  equipmentItems:
+  - {fileID: 11400000, guid: 9fd0aea1c6995794a8ae5a54a1662bcf, type: 2}
+  - {fileID: 11400000, guid: 45e938a30804f964ab9f69c147c7b9c9, type: 2}
+  - {fileID: 11400000, guid: 5bdbecf98282d1148968477099f17041, type: 2}
+  - {fileID: 11400000, guid: 73115051e8b2f47488a248e47d3fbccd, type: 2}
+  - {fileID: 11400000, guid: fc1e36634f4ce4540be04eb96bc679c0, type: 2}
+  - {fileID: 11400000, guid: e67d82a93443a204090643a8bbdec9d8, type: 2}
+  - {fileID: 11400000, guid: 47a41915e5ae5494591a6021240b8c1d, type: 2}
+  - {fileID: 11400000, guid: d4d8bac998410a84594783304bc4a1f9, type: 2}

--- a/Assets/Prefabs/WorldSaveManager.prefab
+++ b/Assets/Prefabs/WorldSaveManager.prefab
@@ -44,13 +44,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e2e41260c9e5194293f5585d22f6c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerManager: {fileID: 0}
+  player: {fileID: 0}
   currentCharacterSaveData:
     characterName: 
     characterLevel: 0
+    currentRightHandWeaponID: 0
+    currentLeftHandWeaponID: 0
+    currentHeadGearItemID: 0
+    currentChestGearItemID: 0
+    currentHandGearItemID: 0
+    currentLegGearItemID: 0
     xPosition: 0
     yPosition: 0
     zPosition: 0
-  fileName: 
+    itemsInWorld:
+      keys: 
+      values: 
+  fileName: SaveGameFile
   saveGame: 0
   loadGame: 0

--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -217,17 +217,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!114 &197883019 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3374036298737047956, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &363725151
 GameObject:
   m_ObjectHideFlags: 0
@@ -496,28 +485,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 435908515}
   m_CullTransparentMesh: 1
---- !u!114 &447048645 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3374036299143256813, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 703fbb9a6cbd1b44d96394ef4fffbebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &601094009 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5779780424125324873, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9e61fdc6d9e73044ea6f0e86e617b6fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &702792444
 GameObject:
   m_ObjectHideFlags: 0
@@ -594,17 +561,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 702792444}
   m_CullTransparentMesh: 1
---- !u!114 &784875777 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4110212348090737349, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7764306d9d5d3e342ba1cf8990d76323, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &864790044
 GameObject:
   m_ObjectHideFlags: 0
@@ -756,10 +712,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7752135827774284195, guid: 23a08f4f452748b40a0a15aa40f80318, type: 3}
-      propertyPath: fileName
-      value: SaveGameFile
-      objectReference: {fileID: 0}
     - target: {fileID: 8173611569960767532, guid: 23a08f4f452748b40a0a15aa40f80318, type: 3}
       propertyPath: m_RootOrder
       value: 4
@@ -951,10 +903,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3125100832193713776, guid: 17cdeaeb221edf74e85fad5f56031769, type: 3}
-      propertyPath: groundedFollowSpeed
-      value: 30
-      objectReference: {fileID: 0}
     - target: {fileID: 3125100832193713777, guid: 17cdeaeb221edf74e85fad5f56031769, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -1184,10 +1132,6 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3374036298944812181, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: m_Name
-      value: Stat Bars
-      objectReference: {fileID: 0}
     - target: {fileID: 3374036299211321305, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -1292,72 +1236,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayerUI
       objectReference: {fileID: 0}
-    - target: {fileID: 4110212349623131902, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: m_UiScaleMode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110212349623131902, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: m_ReferenceResolution.x
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 4110212349623131902, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: m_ReferenceResolution.y
-      value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: focusBar
-      value: 
-      objectReference: {fileID: 2016258081}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: healthBar
-      value: 
-      objectReference: {fileID: 784875777}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: soulCount
-      value: 
-      objectReference: {fileID: 197883019}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: staminaBar
-      value: 
-      objectReference: {fileID: 601094009}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: poisonAmountBar
-      value: 
-      objectReference: {fileID: 447048645}
-    - target: {fileID: 7583938588239694952, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-      propertyPath: poisonBuildUpBar
-      value: 
-      objectReference: {fileID: 1808189634}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
---- !u!1 &1793335851 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4110212349623131900, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
---- !u!225 &1793335852
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1793335851}
-  m_Enabled: 1
-  m_Alpha: 0
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
---- !u!114 &1808189634 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3374036299897520938, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 79b0886c7585ea84584688c8dfcc614b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1837574843
 GameObject:
   m_ObjectHideFlags: 0
@@ -1513,17 +1393,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   worldSceneIndex: 1
---- !u!114 &2016258081 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 546269266459459763, guid: 5f8f6749cc11118419a9be093f9f1f4b, type: 3}
-  m_PrefabInstance: {fileID: 1793335850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e99f58f728bd1814486c1261680f2738, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2088266561
 GameObject:
   m_ObjectHideFlags: 0
@@ -1607,10 +1476,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 876123784018866804, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
-      propertyPath: NetworkConfig.PlayerPrefab
-      value: 
-      objectReference: {fileID: 4086121375157841863, guid: f988b3e3acc5f6847b464bbbe32c332a, type: 3}
     - target: {fileID: 876123784018866805, guid: 44df77e3727569f43b4b8177bef680e4, type: 3}
       propertyPath: m_RootOrder
       value: 3
@@ -1716,42 +1581,49 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.size
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1988c26deec11134fbe97c2b980264fb, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 311163681efcd6b428e73397bf9f5144, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: b61b5ecad97f8f842857785ee3715272, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 32f44fc45c1141b4a8638938b109e01c, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[5]
+      value: 
+      objectReference: {fileID: 11400000, guid: 8b308fd9bb65d8e44b55ed88c725a975, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: abb7cab4b5daf3149b10e080111dff8d, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[7]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5b39c446a406e4c41b9b3b2a233306f3, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[8]
+      value: 
+      objectReference: {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
+    - target: {fileID: 6345208232444783560, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
+      propertyPath: weaponItems.Array.data[9]
+      value: 
+      objectReference: {fileID: 11400000, guid: eee116bfe66806e45ab2bc14d3a0c8e9, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
---- !u!1 &6345208232444783559 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1888462903555093480, guid: c34596650c0acbe48a8b2fdfe895c5e2, type: 3}
-  m_PrefabInstance: {fileID: 6345208232444783558}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6345208232444783560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6345208232444783559}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e670bf20d44966841815b33940e52e9c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  weaponItems:
-  - {fileID: 11400000, guid: 1988c26deec11134fbe97c2b980264fb, type: 2}
-  - {fileID: 11400000, guid: 571c36f2035a94f48aa13c73ae463112, type: 2}
-  - {fileID: 11400000, guid: 311163681efcd6b428e73397bf9f5144, type: 2}
-  - {fileID: 11400000, guid: b61b5ecad97f8f842857785ee3715272, type: 2}
-  - {fileID: 11400000, guid: 32f44fc45c1141b4a8638938b109e01c, type: 2}
-  - {fileID: 11400000, guid: 8b308fd9bb65d8e44b55ed88c725a975, type: 2}
-  - {fileID: 11400000, guid: abb7cab4b5daf3149b10e080111dff8d, type: 2}
-  - {fileID: 11400000, guid: 5b39c446a406e4c41b9b3b2a233306f3, type: 2}
-  - {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
-  - {fileID: 11400000, guid: eee116bfe66806e45ab2bc14d3a0c8e9, type: 2}
-  equipmentItems:
-  - {fileID: 11400000, guid: 9fd0aea1c6995794a8ae5a54a1662bcf, type: 2}
-  - {fileID: 11400000, guid: 45e938a30804f964ab9f69c147c7b9c9, type: 2}
-  - {fileID: 11400000, guid: 5bdbecf98282d1148968477099f17041, type: 2}
-  - {fileID: 11400000, guid: 73115051e8b2f47488a248e47d3fbccd, type: 2}
-  - {fileID: 11400000, guid: fc1e36634f4ce4540be04eb96bc679c0, type: 2}
-  - {fileID: 11400000, guid: e67d82a93443a204090643a8bbdec9d8, type: 2}
-  - {fileID: 11400000, guid: 47a41915e5ae5494591a6021240b8c1d, type: 2}
-  - {fileID: 11400000, guid: d4d8bac998410a84594783304bc4a1f9, type: 2}

--- a/Assets/Scenes/WorldScene_01.unity
+++ b/Assets/Scenes/WorldScene_01.unity
@@ -310,15 +310,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 20179720}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 17.02, y: -4.733, z: -104.42}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 9.540001, y: -4.233, z: 1.300003}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 839032202}
   - {fileID: 851459803}
-  m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &20179722
 SphereCollider:
@@ -1154,7 +1154,7 @@ RectTransform:
   m_Children:
   - {fileID: 1289373858}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1291,6 +1291,75 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 213561350}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &216086903
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1438136248, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1438136248, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747085, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1247414621750747090, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Name
+      value: Enemy_CC
+      objectReference: {fileID: 0}
+    - target: {fileID: 7871449295077461981, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
+      propertyPath: m_Height
+      value: 1.85
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 08d5f5dd3f92d0d40b1a29ceeff7e8ff, type: 3}
 --- !u!1 &226680848
 GameObject:
   m_ObjectHideFlags: 0
@@ -1569,62 +1638,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &245999336
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 245999337}
-  - component: {fileID: 245999338}
-  m_Layer: 9
-  m_Name: RightHandIK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &245999337
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 245999336}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1744594463}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &245999338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 245999336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 7977729983871090516}
-    m_Mid: {fileID: 5672531335148800765}
-    m_Tip: {fileID: 6282815699825232000}
-    m_Target: {fileID: 0}
-    m_Hint: {fileID: 0}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
 --- !u!1 &259238550
 GameObject:
   m_ObjectHideFlags: 0
@@ -7588,7 +7601,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &529954943
 MonoBehaviour:
@@ -8180,7 +8193,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterController: {fileID: 0}
-  anim: {fileID: 0}
+  animator: {fileID: 0}
   characterAnimatorManager: {fileID: 0}
   characterWeaponSlotManager: {fileID: 0}
   characterNetworkManager: {fileID: 0}
@@ -8200,7 +8213,6 @@ MonoBehaviour:
   isGrabbed: 0
   isRotatingWithRootMotion: 0
   canRotate: 0
-  isInAir: 0
   isGrounded: 0
   isTwoHandingWeapon: 0
   isClimbing: 0
@@ -8330,6 +8342,43 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 632211340}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &642458968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 642458969}
+  m_Layer: 0
+  m_Name: TestObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &642458969
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642458968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.4799995, y: -0.5, z: -105.72}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1605946380}
+  - {fileID: 2069176453767592657}
+  - {fileID: 1951752323}
+  - {fileID: 1864118697}
+  - {fileID: 20179721}
+  - {fileID: 2728774238975339044}
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &674897332
 GameObject:
   m_ObjectHideFlags: 0
@@ -20766,62 +20815,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1112935541}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1117275922
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1117275923}
-  - component: {fileID: 1117275924}
-  m_Layer: 9
-  m_Name: LeftHandIK
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1117275923
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1117275922}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1744594463}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1117275924
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1117275922}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aeda7bfbf984f2a4da5ab4b8967b115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Data:
-    m_Root: {fileID: 6749191471678442243}
-    m_Mid: {fileID: 3580520178660990945}
-    m_Tip: {fileID: 9051282064442343688}
-    m_Target: {fileID: 0}
-    m_Hint: {fileID: 0}
-    m_TargetPositionWeight: 1
-    m_TargetRotationWeight: 1
-    m_HintWeight: 1
-    m_MaintainTargetPositionOffset: 0
-    m_MaintainTargetRotationOffset: 0
 --- !u!1 &1152921791
 GameObject:
   m_ObjectHideFlags: 0
@@ -21407,12 +21400,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1211580253}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.5, y: -1, z: -18.99}
+  m_LocalPosition: {x: -0.28999996, y: -1, z: -0.020000458}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1211580255
 MonoBehaviour:
@@ -22326,12 +22319,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1298631735}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.5, y: 1.5, z: 0.994}
+  m_LocalPosition: {x: -0.28999996, y: 1.5, z: 19.963999}
   m_LocalScale: {x: 4, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1298631740
 MonoBehaviour:
@@ -33313,7 +33306,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1585748728}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
+  m_LocalPosition: {x: 3.21, y: -1, z: 18.97}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -33409,7 +33402,7 @@ Transform:
   - {fileID: 445648762}
   - {fileID: 1254032652}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1605946378
 GameObject:
@@ -33450,13 +33443,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1605946378}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.48, y: -0.5, z: -105.72}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1606065957
 GameObject:
@@ -34364,54 +34357,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1734377443}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1744594461
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1744594463}
-  - component: {fileID: 1744594462}
-  m_Layer: 9
-  m_Name: RigLayer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1744594462
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1744594461}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors: []
---- !u!4 &1744594463
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1744594461}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 245999337}
-  - {fileID: 1117275923}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1748176402
 GameObject:
   m_ObjectHideFlags: 0
@@ -39592,7 +39537,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1804018007}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 3.21, y: 0, z: 18.97}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -39601,7 +39546,7 @@ Transform:
   - {fileID: 693988326}
   - {fileID: 211704102}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1842569823
 GameObject:
@@ -39904,13 +39849,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1864118693}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8.37, y: -2.7569, z: -105.2981}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.8899994, y: -2.2569008, z: 0.4218979}
   m_LocalScale: {x: 4.472, y: 4.4860606, z: 4.3362}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1865782364
 GameObject:
@@ -40226,15 +40171,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1951752322}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.6399956, y: -4.5, z: -102.254}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -8.119995, y: -4, z: 3.4660034}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 259238554}
   - {fileID: 1292124819}
-  m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1960719340
 GameObject:
@@ -40530,56 +40475,6 @@ Transform:
   m_Father: {fileID: 1585748729}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1971945225
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1971945227}
-  - component: {fileID: 1971945226}
-  m_Layer: 9
-  m_Name: BackSlot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1971945226
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1971945225}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47d4cfcd17f34e744bb8fdb2ac78c47b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentOverride: {fileID: 1971945227}
-  isLeftHandSlot: 0
-  isRightHandSlot: 0
-  isBackSlot: 1
-  currentWeapon: {fileID: 0}
-  currentWeaponModel: {fileID: 0}
---- !u!4 &1971945227
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1971945225}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1351055107741937949}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1973198175
 GameObject:
   m_ObjectHideFlags: 0
@@ -40708,50 +40603,6 @@ Transform:
   - {fileID: 2004443219}
   m_Father: {fileID: 1804018008}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1987981444
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1987981446}
-  - component: {fileID: 1987981445}
-  m_Layer: 9
-  m_Name: DeadState
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1987981445
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1987981444}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9cafd46b31467164e81b98beb219eec5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1987981446
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1987981444}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2004443218
 PrefabInstance:
@@ -41734,24 +41585,6 @@ Transform:
   m_Father: {fileID: 1285067551106426507}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &106562713054175943
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2710195902211508933}
-  m_LocalRotation: {x: 0.42928478, y: -0.52979195, z: 0.49031618, w: 0.54279387}
-  m_LocalPosition: {x: -0.12164436, y: -0.000000014901161, z: 0.000000013038516}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4449593293612772399}
-  - {fileID: 2222786320982746779}
-  - {fileID: 1719699630006140884}
-  m_Father: {fileID: 5828659720317751899}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &107391724022213794
 Transform:
   m_ObjectHideFlags: 0
@@ -41784,105 +41617,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!137 &113127646290131704
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7202887979638949049}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 611b9d6b7da80f5419ff2ea86ed603af, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 6856591950794880597, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_Bones:
-  - {fileID: 2783984255777969060}
-  - {fileID: 7717444924548114404}
-  - {fileID: 7365439574029380290}
-  - {fileID: 3260685853615109565}
-  - {fileID: 6293304847458540895}
-  - {fileID: 5499146885587411047}
-  - {fileID: 8385787491082885542}
-  - {fileID: 1351055107741937949}
-  - {fileID: 8480182534368302927}
-  - {fileID: 7551236085092406015}
-  - {fileID: 5828659720317751899}
-  - {fileID: 5932876856517045203}
-  - {fileID: 188774370174377083}
-  - {fileID: 8551034585152293605}
-  - {fileID: 2077808291976089077}
-  - {fileID: 106562713054175943}
-  - {fileID: 6749191471678442243}
-  - {fileID: 7977729983871090516}
-  - {fileID: 3973040660317438724}
-  - {fileID: 4819955728311668068}
-  - {fileID: 3580520178660990945}
-  - {fileID: 5672531335148800765}
-  - {fileID: 9051282064442343688}
-  - {fileID: 6282815699825232000}
-  - {fileID: 6082085879450899395}
-  - {fileID: 8671589710391629568}
-  - {fileID: 4236985576475643806}
-  - {fileID: 2903460674201690944}
-  - {fileID: 973694463337861414}
-  - {fileID: 2082306000000839855}
-  - {fileID: 6557065754621394893}
-  - {fileID: 7514345698659232330}
-  - {fileID: 421430676999905617}
-  - {fileID: 7045894727690539837}
-  - {fileID: 6936919367508955919}
-  - {fileID: 1183721638923940508}
-  - {fileID: 5221542145887107602}
-  - {fileID: 7462824495301902313}
-  - {fileID: 2942299695292835564}
-  - {fileID: 2567597172372777715}
-  - {fileID: 3069193874456748922}
-  - {fileID: 5012670288610550331}
-  - {fileID: 5998905013868159310}
-  - {fileID: 873983886187059957}
-  - {fileID: 5675170240245011131}
-  - {fileID: 8490854622526040569}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2783984255777969060}
-  m_AABB:
-    m_Center: {x: 0.02152279, y: -0.009413511, z: 0}
-    m_Extent: {x: 0.9414129, y: 0.2786869, z: 1.0245608}
-  m_DirtyAABB: 0
 --- !u!1 &134924773426096882
 GameObject:
   m_ObjectHideFlags: 0
@@ -42003,43 +41737,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.43480468, y: 0.73867637, z: 0.039147377}
   m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.06705713}
---- !u!95 &181790469199886445
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_Avatar: {fileID: 9000000, guid: a549c311ccb97134ea2ad4c9a33d0dee, type: 3}
-  m_Controller: {fileID: 9100000, guid: 8614f27ef2a866645aa6fdfd08ce7377, type: 2}
-  m_CullingMode: 1
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 1
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!4 &188774370174377083
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6521956822721154984}
-  m_LocalRotation: {x: 0.6243446, y: 0.50307226, z: 0.41116875, w: -0.43365029}
-  m_LocalPosition: {x: -0.05801529, y: -0.04191418, z: 0.0744715}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7977729983871090516}
-  m_Father: {fileID: 1351055107741937949}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &212062004553637124
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -42422,22 +42119,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!1 &280723614724625919
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2927160198095412280}
-  m_Layer: 9
-  m_Name: Root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &300163563009439788
 GameObject:
   m_ObjectHideFlags: 0
@@ -47062,22 +46743,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &421430676999905617
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1675946250807933005}
-  m_LocalRotation: {x: 0.022871796, y: 0.016431663, z: 0.36629796, w: 0.9300714}
-  m_LocalPosition: {x: -0.04248817, y: -0.000000023621396, z: 0.0000000010913936}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2942299695292835564}
-  m_Father: {fileID: 4236985576475643806}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &439079302320727558
 GameObject:
   m_ObjectHideFlags: 0
@@ -47125,22 +46790,6 @@ Transform:
   m_Father: {fileID: 1993777798612748880}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &530734438948225233
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5672531335148800765}
-  m_Layer: 9
-  m_Name: Elbow_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &541362737388075452
 Transform:
   m_ObjectHideFlags: 0
@@ -47333,7 +46982,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 263172850425384044}
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: -3.5, y: 1.98, z: 24}
+  m_LocalPosition: {x: -0.28999996, y: 1.98, z: 42.97}
   m_LocalScale: {x: 1.25, y: 1.25, z: 1.25}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -47347,7 +46996,7 @@ Transform:
   - {fileID: 2173030236655096893}
   - {fileID: 1452509296}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &665591147063346427
 Transform:
@@ -47391,22 +47040,6 @@ GameObject:
   - component: {fileID: 9198166403502727530}
   m_Layer: 9
   m_Name: Finger_02_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &712329317847661737
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3069193874456748922}
-  m_Layer: 9
-  m_Name: IndexFinger_03_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -47494,21 +47127,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &873983886187059957
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5405922365339706444}
-  m_LocalRotation: {x: 0.01664637, y: 0.096525334, z: -0.16913006, w: 0.98071444}
-  m_LocalPosition: {x: -0.030032393, y: 1.1368684e-15, z: 7.105427e-17}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2942299695292835564}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &899071799610693104
 GameObject:
   m_ObjectHideFlags: 0
@@ -47549,7 +47167,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 555133620618040184}
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0.01, y: -0.75, z: -16.8}
+  m_LocalPosition: {x: 3.22, y: -0.75, z: 2.17}
   m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -47557,7 +47175,7 @@ Transform:
   - {fileID: 6017392760040507481}
   - {fileID: 1212191469}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &947308383056934313
 GameObject:
@@ -47575,22 +47193,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &973694463337861414
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2089014045213506166}
-  m_LocalRotation: {x: -0.013495237, y: 0.12788932, z: 0.020216519, w: -0.9914906}
-  m_LocalPosition: {x: 0.10396602, y: -0.0039899843, z: -0.026726522}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6936919367508955919}
-  m_Father: {fileID: 6282815699825232000}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &974612555387330456
 GameObject:
   m_ObjectHideFlags: 0
@@ -47607,21 +47209,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &983888367037084498
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7144434199710357051}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2927160198095412280}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &999547179008513038
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -47854,7 +47441,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1152895628869660359
 MonoBehaviour:
@@ -47896,22 +47483,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1168657437883747327
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7365439574029380290}
-  m_Layer: 9
-  m_Name: UpperLeg_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1174502899127546609
 GameObject:
   m_ObjectHideFlags: 0
@@ -47928,22 +47499,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1183721638923940508
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7375749217189888505}
-  m_LocalRotation: {x: -0.022789175, y: -0.016550567, z: -0.3618357, w: -0.9318164}
-  m_LocalPosition: {x: 0.042488072, y: 0.00000028777868, z: -0.000000016763806}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5012670288610550331}
-  m_Father: {fileID: 2082306000000839855}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1198549574283998166
 GameObject:
   m_ObjectHideFlags: 0
@@ -47955,39 +47510,6 @@ GameObject:
   - component: {fileID: 2897400521139192960}
   m_Layer: 9
   m_Name: Shoulder_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1203118738369361368
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2783984255777969060}
-  m_Layer: 9
-  m_Name: Hips
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1251083813410915910
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6282815699825232000}
-  - component: {fileID: 6389220527282679362}
-  m_Layer: 9
-  m_Name: Hand_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -48066,57 +47588,6 @@ Transform:
   m_Father: {fileID: 6808192710378490903}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1322399583730087400
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6597885023117375245}
-  m_Layer: 9
-  m_Name: Prop_Attachment_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1330335877044071151
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8385787491082885542}
-  m_Layer: 9
-  m_Name: LowerLeg_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1351055107741937949
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6890761910560796752}
-  m_LocalRotation: {x: 0.9918718, y: -0.121152095, z: 0.016842717, w: -0.03505519}
-  m_LocalPosition: {x: -0.17903721, y: -0.000000014901161, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5932876856517045203}
-  - {fileID: 188774370174377083}
-  - {fileID: 5828659720317751899}
-  - {fileID: 1971945227}
-  m_Father: {fileID: 6293304847458540895}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1361456706802018327
 Transform:
   m_ObjectHideFlags: 0
@@ -48164,22 +47635,6 @@ Transform:
   m_Father: {fileID: 8148366492450581619}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1466712948932171297
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3702804517332685512}
-  m_Layer: 9
-  m_Name: Prop_Attachment_Extra1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1496422365765279092
 GameObject:
   m_ObjectHideFlags: 0
@@ -48304,38 +47759,6 @@ Transform:
   m_Father: {fileID: 6069968552624491209}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1675946250807933005
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 421430676999905617}
-  m_Layer: 9
-  m_Name: Finger_02_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1692603784858004234
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2567597172372777715}
-  m_Layer: 9
-  m_Name: Thumb_03_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &1701432632499504374
 Transform:
   m_ObjectHideFlags: 0
@@ -48351,37 +47774,6 @@ Transform:
   - {fileID: 541362737388075452}
   m_Father: {fileID: 1321667985525707518}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1703193932982959427
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6082085879450899395}
-  m_Layer: 9
-  m_Name: Thumb_01_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1719699630006140884
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6408564107096017747}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.4071082e-15, y: 0.21543543, z: 0.010532023}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 106562713054175943}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1811522620321057668
 GameObject:
@@ -48426,22 +47818,6 @@ GameObject:
   - component: {fileID: 2052609931021960217}
   m_Layer: 9
   m_Name: Thumb_02_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1848742016884038073
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2222786320982746779}
-  m_Layer: 9
-  m_Name: Eyes
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -48573,22 +47949,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &2030180832677899186
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7604200603854571016}
-  m_Layer: 9
-  m_Name: Fx_Attachment
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &2052609931021960217
 Transform:
   m_ObjectHideFlags: 0
@@ -48613,63 +47973,15 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8833811443276046813}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.5, y: -5.11, z: -99.98}
+  m_LocalPosition: {x: -6.9799995, y: -4.6100006, z: 5.739998}
   m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3497445773848764024}
   - {fileID: 7340171136604914892}
-  m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2077808291976089077
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7819668629950243218}
-  m_LocalRotation: {x: 0.000000008877997, y: 0.000000005690149, z: -0.2700158, w: 0.96285594}
-  m_LocalPosition: {x: 0.11284034, y: -0.000000018626451, z: -0.000000007450581}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4819955728311668068}
-  m_Father: {fileID: 7551236085092406015}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2082306000000839855
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6144163813531970513}
-  m_LocalRotation: {x: -0.033403162, y: 0.13207105, z: -0.16915055, w: -0.97612995}
-  m_LocalPosition: {x: 0.099825, y: 0.0011600349, z: 0.032833427}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1183721638923940508}
-  m_Father: {fileID: 6282815699825232000}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2089014045213506166
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 973694463337861414}
-  m_Layer: 9
-  m_Name: IndexFinger_01_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &2095106435520203993
 Transform:
   m_ObjectHideFlags: 0
@@ -49467,22 +48779,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &2180513304525126737
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5499146885587411047}
-  m_Layer: 9
-  m_Name: LowerLeg_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &2192406749914345607
 GameObject:
   m_ObjectHideFlags: 0
@@ -49494,53 +48790,6 @@ GameObject:
   - component: {fileID: 5863313950178018304}
   m_Layer: 9
   m_Name: Head_Attachment
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &2200862012189808596
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8490854622526040569}
-  m_Layer: 9
-  m_Name: Finger_04_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2222786320982746779
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1848742016884038073}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.09271572, z: 0.12272215}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 106562713054175943}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2247840065108990653
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5012670288610550331}
-  m_Layer: 9
-  m_Name: Finger_03_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -49562,22 +48811,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &2289990393877702049
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6293304847458540895}
-  m_Layer: 9
-  m_Name: Spine_02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &2307786862567353602
 GameObject:
   m_ObjectHideFlags: 0
@@ -49589,22 +48822,6 @@ GameObject:
   - component: {fileID: 7950560543100476728}
   m_Layer: 9
   m_Name: Finger_03_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &2316814359032618144
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4236985576475643806}
-  m_Layer: 9
-  m_Name: Finger_01_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -49657,22 +48874,6 @@ Transform:
   m_Father: {fileID: 4998125333555966092}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2380868480718890050
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8551034585152293605}
-  m_Layer: 9
-  m_Name: Ball_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &2383092626000397373
 Transform:
   m_ObjectHideFlags: 0
@@ -49749,22 +48950,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
---- !u!1 &2546708163793699346
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6981905998638309523}
-  m_Layer: 9
-  m_Name: Hips_Attachment
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &2565921385957651345
 Transform:
   m_ObjectHideFlags: 0
@@ -49779,21 +48964,6 @@ Transform:
   m_Children:
   - {fileID: 1901845083700446393}
   m_Father: {fileID: 719541677359331636}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2567597172372777715
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1692603784858004234}
-  m_LocalRotation: {x: 0.042597283, y: 0.25559175, z: 0.23750533, w: -0.9361888}
-  m_LocalPosition: {x: 0.056655083, y: 0.00000007264316, z: -0.00000021979213}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7045894727690539837}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2573975977644861850
@@ -49943,22 +49113,6 @@ GameObject:
   - component: {fileID: 3497445773848764024}
   m_Layer: 0
   m_Name: LeverPivot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &2614629579683808612
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6293622914572010570}
-  m_Layer: 9
-  m_Name: Prop_Attachment_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -50329,22 +49483,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &2710195902211508933
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 106562713054175943}
-  m_Layer: 9
-  m_Name: Head
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &2712596641624731119
 GameObject:
   m_ObjectHideFlags: 0
@@ -50369,13 +49507,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8542214994791566848}
   m_LocalRotation: {x: -0, y: -0.7123876, z: -0, w: 0.7017862}
-  m_LocalPosition: {x: 7.95, y: -4.999933, z: -102.93}
+  m_LocalPosition: {x: 0.47000027, y: -4.499933, z: 2.790001}
   m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 716617325}
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_Father: {fileID: 642458969}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2740078799193833803
 GameObject:
@@ -50476,25 +49614,6 @@ Transform:
   m_Father: {fileID: 6926966846658439280}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2783984255777969060
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1203118738369361368}
-  m_LocalRotation: {x: 0.4644048, y: -0.533213, z: -0.45846716, w: 0.5383493}
-  m_LocalPosition: {x: 0.0014336109, y: 0.9057569, z: -0.025198698}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6981905998638309523}
-  - {fileID: 7717444924548114404}
-  - {fileID: 3260685853615109565}
-  - {fileID: 7365439574029380290}
-  m_Father: {fileID: 2927160198095412280}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &2794437535457143003
 Transform:
   m_ObjectHideFlags: 0
@@ -50527,72 +49646,6 @@ Transform:
   m_Father: {fileID: 7982664780069296276}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2853968160758623339
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527869462210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 77eaffa227fc0d94d8161de7ed9e274d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!195 &2853968160939175723
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2853968160939175733}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 26
-  avoidancePriority: 50
-  m_AngularSpeed: 800
-  m_StoppingDistance: 0.5
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 0
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
---- !u!4 &2853968160939175732
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2853968160939175733}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2853968160939175733
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2853968160939175732}
-  - component: {fileID: 2853968160939175723}
-  m_Layer: 9
-  m_Name: NavMesh Agent
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &2863651618377935332
 Transform:
   m_ObjectHideFlags: 0
@@ -50623,22 +49676,6 @@ Transform:
   - {fileID: 593301399077908777}
   m_Father: {fileID: 4908250698437093295}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2903460674201690944
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4070522368515471522}
-  m_LocalRotation: {x: -0.11694848, y: -0.1735315, z: -0.35610104, w: -0.9107151}
-  m_LocalPosition: {x: 0.035139985, y: 0.011709997, z: -0.045055427}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7045894727690539837}
-  m_Father: {fileID: 6282815699825232000}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2918362561825530426
 MeshRenderer:
@@ -50700,25 +49737,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2927160198095412280
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 280723614724625919}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7604200603854571016}
-  - {fileID: 2783984255777969060}
-  - {fileID: 3702804517332685512}
-  - {fileID: 983888367037084498}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2940120312579478492
 GameObject:
   m_ObjectHideFlags: 0
@@ -50735,22 +49753,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2942299695292835564
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7387542382376720086}
-  m_LocalRotation: {x: 0.0054590213, y: -0.030513607, z: 0.4087086, w: 0.91213846}
-  m_LocalPosition: {x: -0.03513328, y: 0.000000037740392, z: 0.0000000010732037}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 873983886187059957}
-  m_Father: {fileID: 421430676999905617}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &2955331232928170798
 Transform:
   m_ObjectHideFlags: 0
@@ -50829,22 +49831,6 @@ Transform:
   m_Father: {fileID: 9198166403502727530}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &3069193874456748922
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 712329317847661737}
-  m_LocalRotation: {x: 0.044269163, y: 0.022257227, z: -0.15307403, w: -0.98697174}
-  m_LocalPosition: {x: 0.037912127, y: 0.000003280118, z: -0.00000005029142}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5675170240245011131}
-  m_Father: {fileID: 6936919367508955919}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3180614763329684103
 GameObject:
   m_ObjectHideFlags: 0
@@ -50875,22 +49861,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 8295283828993285635}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &3260685853615109565
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6581110072837808292}
-  m_LocalRotation: {x: -0.72358024, y: -0.05821991, z: -0.024835788, w: 0.6873321}
-  m_LocalPosition: {x: 0.0411578, y: -0.026920758, z: 0.098967105}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8385787491082885542}
-  m_Father: {fileID: 2783984255777969060}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3270263638707982350
 GameObject:
@@ -51052,54 +50022,6 @@ Transform:
   m_Father: {fileID: 2069176453767592657}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3512309880408183960
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3580520178660990945}
-  m_Layer: 9
-  m_Name: Elbow_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3580520178660990945
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3512309880408183960}
-  m_LocalRotation: {x: -0.09152292, y: 0.2011993, z: 0.034261495, w: 0.9746633}
-  m_LocalPosition: {x: -0.33947405, y: -0.0014491217, z: -0.0014362646}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9051282064442343688}
-  m_Father: {fileID: 6749191471678442243}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3603312035634020129
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8480182534368302927}
-  m_Layer: 9
-  m_Name: Ankle_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &3630726969790437621
 Transform:
   m_ObjectHideFlags: 0
@@ -51178,21 +50100,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 221697119119972847}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &3702804517332685512
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1466712948932171297}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2927160198095412280}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3718647220484777075
 GameObject:
@@ -51397,21 +50304,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3973040660317438724
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5319674376675070765}
-  m_LocalRotation: {x: 3.8191672e-14, y: -0.7071068, z: 3.3750773e-14, w: 0.7071068}
-  m_LocalPosition: {x: -0.07295759, y: -1.4832047e-10, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8551034585152293605}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3973533913941383333
 GameObject:
   m_ObjectHideFlags: 0
@@ -51423,22 +50315,6 @@ GameObject:
   - component: {fileID: 8653251758179855394}
   m_Layer: 9
   m_Name: Head_Attachment
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &4070522368515471522
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2903460674201690944}
-  m_Layer: 9
-  m_Name: Thumb_01_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -51597,6 +50473,8 @@ MonoBehaviour:
   currentFocus: 0
   soulCount: 0
   isBoss: 0
+  currentEquipLoad: 0
+  maxEquipLoad: 0
   totalPoiseDefense: 0
   offensivePoiseBonus: 0
   armorPoiseBonus: 0
@@ -51762,22 +50640,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &4146173160704365120
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5932876856517045203}
-  m_Layer: 9
-  m_Name: Clavicle_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &4173200938779352052
 GameObject:
   m_ObjectHideFlags: 0
@@ -51868,7 +50730,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4198961207606102453}
   m_LocalRotation: {x: 0, y: -0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 11.4, y: 3.486, z: -9.37}
+  m_LocalPosition: {x: 14.61, y: 3.486, z: 9.599999}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -51882,7 +50744,7 @@ Transform:
   - {fileID: 234600872}
   - {fileID: 917399107}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &4198961207606102453
 GameObject:
@@ -51959,22 +50821,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4236985576475643806
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2316814359032618144}
-  m_LocalRotation: {x: -0.0033722788, y: -0.028836798, z: 0.16308427, w: 0.9861849}
-  m_LocalPosition: {x: -0.09982523, y: -0.0011595332, z: -0.0328334}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 421430676999905617}
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4260308901660310236
 Transform:
   m_ObjectHideFlags: 0
@@ -52044,110 +50890,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &4436255636332385968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436255636332385970}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7764306d9d5d3e342ba1cf8990d76323, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  slider: {fileID: 4436255636332385969}
---- !u!114 &4436255636332385969
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436255636332385970}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 0
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 0
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 0
-  m_TargetGraphic: {fileID: 0}
-  m_FillRect: {fileID: 6389220527720015979}
-  m_HandleRect: {fileID: 0}
-  m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
-  m_OnValueChanged:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!1 &4436255636332385970
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4436255636332385971}
-  - component: {fileID: 4436255636332385969}
-  - component: {fileID: 4436255636332385968}
-  m_Layer: 5
-  m_Name: HealthBarSlider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4436255636332385971
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4436255636332385970}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6389220526957520226}
-  - {fileID: 6389220527720015979}
-  m_Father: {fileID: 6389220527793417461}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 2}
-  m_SizeDelta: {x: 1, y: 0.2}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!4 &4440213890271475749
 Transform:
   m_ObjectHideFlags: 0
@@ -52164,37 +50906,6 @@ Transform:
   m_Father: {fileID: 9040121267442164459}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4449593293612772399
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4503298778525882954}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.1276692, z: 0.12272215}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 106562713054175943}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4503298778525882954
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4449593293612772399}
-  m_Layer: 9
-  m_Name: Eyebrows
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &4527412500396092628
 Transform:
   m_ObjectHideFlags: 0
@@ -52244,22 +50955,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &4653582942744567250
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5998905013868159310}
-  m_Layer: 9
-  m_Name: IndexFinger_04_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &4746434889187179269
 GameObject:
   m_ObjectHideFlags: 0
@@ -52292,58 +50987,6 @@ Transform:
   m_Father: {fileID: 5289950539484381266}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4801110032343833624
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 66b1fbb68c1540b4eb2b5bc3ff4932da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  characterEffectsManager: {fileID: 0}
-  unarmedWeapon: {fileID: 11400000, guid: 1988c26deec11134fbe97c2b980264fb, type: 2}
-  leftHandSlot: {fileID: 6389220526692870798}
-  rightHandSlot: {fileID: 6389220527282679362}
-  backSlot: {fileID: 1971945226}
-  leftHandDamageCollider: {fileID: 0}
-  rightHandDamageCollider: {fileID: 0}
-  attackingWeapon: {fileID: 0}
-  rightHandIKTarget: {fileID: 0}
-  leftHandIKTarget: {fileID: 0}
---- !u!114 &4801110032343833629
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5e13273d7fbe9a54aa7795df635a921f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  canRotate: 0
-  leftHandConstraint: {fileID: 1117275924}
-  rightHandConstraint: {fileID: 245999338}
---- !u!4 &4819955728311668068
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7304826047865599955}
-  m_LocalRotation: {x: 0.00000026481644, y: -0.7071068, z: 0.00000026481635, w: 0.7071068}
-  m_LocalPosition: {x: 0.0729575, y: -7.3880635e-10, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2077808291976089077}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4836172132567599542
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -52368,22 +51011,6 @@ Transform:
   m_Father: {fileID: 8957658171243902026}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4893388962323124593
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5100446468200354008}
-  m_Layer: 9
-  m_Name: Target
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &4908250698437093295
 Transform:
   m_ObjectHideFlags: 0
@@ -52427,53 +51054,6 @@ GameObject:
   - component: {fileID: 7934333167194171372}
   m_Layer: 9
   m_Name: Root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5012670288610550331
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2247840065108990653}
-  m_LocalRotation: {x: -0.005326134, y: 0.030390467, z: -0.40430483, w: -0.9141038}
-  m_LocalPosition: {x: 0.03513327, y: -0.00000014156103, z: 0.0000000144355}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8490854622526040569}
-  m_Father: {fileID: 1183721638923940508}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &5100446468200354008
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4893388962323124593}
-  m_LocalRotation: {x: -0.46203893, y: 0.53527564, z: 0.46203893, w: 0.53527564}
-  m_LocalPosition: {x: 0.006935013, y: 0.035117745, z: 3.2494063e-16}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6293304847458540895}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5117910844063252522
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7514345698659232330}
-  m_Layer: 9
-  m_Name: IndexFinger_02_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -52548,21 +51128,6 @@ Transform:
   m_Father: {fileID: 1612493627173120399}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &5221542145887107602
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6462886351047640612}
-  m_LocalRotation: {x: -0.06197722, y: -0.17259754, z: -0.23208837, w: 0.9552507}
-  m_LocalPosition: {x: -0.056655705, y: 0.0000000146683306, z: 0.000000007916242}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6557065754621394893}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &5289950539484381266
 Transform:
   m_ObjectHideFlags: 0
@@ -52582,119 +51147,6 @@ Transform:
   m_Father: {fileID: 5139807438615400398}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5318091681825837757
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6749191471678442243}
-  m_Layer: 9
-  m_Name: Shoulder_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &5319674376675070765
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3973040660317438724}
-  m_Layer: 9
-  m_Name: Toes_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &5324564050113085441
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5324564050113085470}
-  - component: {fileID: 181790469199886445}
-  - component: {fileID: 5324564050113085468}
-  - component: {fileID: 5324564050113085471}
-  - component: {fileID: 4801110032343833629}
-  - component: {fileID: 4801110032343833624}
-  - component: {fileID: 9058321785823695558}
-  - component: {fileID: 6389220527422649759}
-  - component: {fileID: 6389220527422649730}
-  - component: {fileID: 9058321785823695559}
-  - component: {fileID: 9058321785823695560}
-  - component: {fileID: 9058321785823695561}
-  m_Layer: 9
-  m_Name: Enemy
-  m_TagString: Character
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!136 &5324564050113085468
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.4
-  m_Height: 1.7977306
-  m_Direction: 1
-  m_Center: {x: -0, y: 0.91242343, z: -0}
---- !u!4 &5324564050113085470
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: -3.5, y: -1, z: -2}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6175693759045611578}
-  - {fileID: 2927160198095412280}
-  - {fileID: 6389220527869462209}
-  - {fileID: 2853968160939175732}
-  - {fileID: 6389220527869295477}
-  - {fileID: 6389220526931123927}
-  - {fileID: 6389220526242444112}
-  - {fileID: 6389220527647780841}
-  - {fileID: 1744594463}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
---- !u!54 &5324564050113085471
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.01
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 112
-  m_CollisionDetection: 0
 --- !u!1 &5325303215150246062
 GameObject:
   m_ObjectHideFlags: 0
@@ -52745,22 +51197,6 @@ Transform:
   m_Father: {fileID: 7950560543100476728}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5402367105864248868
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6664765756323621352}
-  m_Layer: 9
-  m_Name: Shield_Attachment_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &5404447920140479218
 Transform:
   m_ObjectHideFlags: 0
@@ -52777,22 +51213,6 @@ Transform:
   m_Father: {fileID: 1275150759402566484}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5405922365339706444
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 873983886187059957}
-  m_Layer: 9
-  m_Name: Finger_04_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &5414536260254730374
 Transform:
   m_ObjectHideFlags: 0
@@ -52824,22 +51244,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5499146885587411047
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2180513304525126737}
-  m_LocalRotation: {x: 0.69640523, y: 0.046938326, z: -0.030142298, w: 0.7154775}
-  m_LocalPosition: {x: -0.39930907, y: 0.000000059604645, z: 1.2738255e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8480182534368302927}
-  m_Father: {fileID: 7365439574029380290}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &5506476369919670533
 Transform:
   m_ObjectHideFlags: 0
@@ -52871,22 +51275,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5672531335148800765
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 530734438948225233}
-  m_LocalRotation: {x: -0.109417275, y: 0.22795282, z: 0.024202544, w: 0.96720195}
-  m_LocalPosition: {x: 0.3394746, y: 0.0014476385, z: 0.0014362596}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6282815699825232000}
-  m_Father: {fileID: 7977729983871090516}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5674980110648424372
 GameObject:
   m_ObjectHideFlags: 0
@@ -52903,21 +51291,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5675170240245011131
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7825207731729437430}
-  m_LocalRotation: {x: -0.004519649, y: -0.028039929, z: -0.15906802, w: 0.986859}
-  m_LocalPosition: {x: 0.037793327, y: -0.0000052657088, z: -0.0000001550738}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3069193874456748922}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5720001396505380733
 GameObject:
   m_ObjectHideFlags: 0
@@ -52950,22 +51323,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5828659720317751899
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437631042699648935}
-  m_LocalRotation: {x: 0.000000003705289, y: 0.0000000013216378, z: 0.041733377, w: 0.99912876}
-  m_LocalPosition: {x: -0.111889705, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 106562713054175943}
-  m_Father: {fileID: 1351055107741937949}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5846165519888696983
 GameObject:
   m_ObjectHideFlags: 0
@@ -53060,22 +51417,6 @@ Transform:
   m_Father: {fileID: 7976307229090525489}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &5932876856517045203
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4146173160704365120}
-  m_LocalRotation: {x: -0.5020848, y: 0.6266735, z: -0.4337061, w: -0.40876657}
-  m_LocalPosition: {x: -0.058011726, y: -0.041914478, z: -0.07447154}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6749191471678442243}
-  m_Father: {fileID: 1351055107741937949}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5970078675738537461
 GameObject:
   m_ObjectHideFlags: 0
@@ -53092,21 +51433,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5998905013868159310
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4653582942744567250}
-  m_LocalRotation: {x: -0.004519649, y: -0.028039929, z: -0.15906802, w: 0.986859}
-  m_LocalPosition: {x: -0.03779794, y: -1.4210854e-15, z: 7.105427e-17}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7462824495301902313}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &6017392760040507481
 Transform:
   m_ObjectHideFlags: 0
@@ -53140,22 +51466,6 @@ Transform:
   - {fileID: 2126279254}
   m_Father: {fileID: 1285067551106426507}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6082085879450899395
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1703193932982959427}
-  m_LocalRotation: {x: 0.10272303, y: 0.13435821, z: 0.3131672, w: 0.934517}
-  m_LocalPosition: {x: -0.035140503, y: -0.011706891, z: 0.04505539}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6557065754621394893}
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6113968690402545212
 GameObject:
@@ -53205,53 +51515,6 @@ Transform:
   m_Father: {fileID: 1321667985525707518}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6144163813531970513
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2082306000000839855}
-  m_Layer: 9
-  m_Name: Finger_01_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6175693759045611578
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7202887979638949049}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6206293677396084738
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7977729983871090516}
-  m_Layer: 9
-  m_Name: Shoulder_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6210854579841125900
 GameObject:
   m_ObjectHideFlags: 0
@@ -53279,22 +51542,6 @@ GameObject:
   - component: {fileID: 4440213890271475749}
   m_Layer: 9
   m_Name: Clavicle_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &6233126484941713693
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7717444924548114404}
-  m_Layer: 9
-  m_Name: Spine_01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -53331,57 +51578,6 @@ Transform:
   - {fileID: 221697119119972847}
   m_Father: {fileID: 6514143556207119227}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6282815699825232000
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1251083813410915910}
-  m_LocalRotation: {x: -0.15530588, y: -0.07220194, z: -0.03288075, w: 0.9846755}
-  m_LocalPosition: {x: 0.27114487, y: -0.00000003259629, z: 0.00038135424}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2082306000000839855}
-  - {fileID: 973694463337861414}
-  - {fileID: 6293622914572010570}
-  - {fileID: 2903460674201690944}
-  m_Father: {fileID: 5672531335148800765}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6293304847458540895
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2289990393877702049}
-  m_LocalRotation: {x: 0.9948446, y: -0.09800402, z: -0.019615274, w: 0.01716675}
-  m_LocalPosition: {x: -0.18151172, y: -0.000000029802322, z: 0.000000013969839}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1351055107741937949}
-  - {fileID: 5100446468200354008}
-  m_Father: {fileID: 7717444924548114404}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6293622914572010570
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2614629579683808612}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: -4.440892e-18}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6282815699825232000}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6320372804178029396
 GameObject:
@@ -53447,947 +51643,6 @@ Transform:
   m_Father: {fileID: 5186356157424572691}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6389220526242444112
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526242444113}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6389220527865628190}
-  - {fileID: 7294613998697194322}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220526242444113
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526242444112}
-  m_Layer: 9
-  m_Name: Combat Transform
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &6389220526286626672
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526286626679}
-  - component: {fileID: 6389220526286626678}
-  m_Layer: 9
-  m_Name: Attack State
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &6389220526286626678
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526286626672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc0a2ff724e39e7429d7c5bd1496ef55, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rotateTowardsTargetState: {fileID: 9164903153475300613}
-  combatStanceState: {fileID: 6389220527889128876}
-  pursueTargetState: {fileID: 6389220526643944728}
-  currentAttack: {fileID: 0}
-  deadState: {fileID: 1987981445}
-  hasPerformedAttack: 0
---- !u!4 &6389220526286626679
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526286626672}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6389220526372162101
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526372162103}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e4da985b6209e9418bdec8ce0602eff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  detectionLayer:
-    serializedVersion: 2
-    m_Bits: 2048
-  pursueTargetState: {fileID: 6389220526643944728}
-  deadState: {fileID: 1987981445}
---- !u!4 &6389220526372162102
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526372162103}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220526372162103
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526372162102}
-  - component: {fileID: 6389220526372162101}
-  m_Layer: 9
-  m_Name: Idle State
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &6389220526639570980
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526639570987}
-  - component: {fileID: 6389220526639570985}
-  - component: {fileID: 6389220526639570984}
-  - component: {fileID: 7294613999552322113}
-  m_Layer: 12
-  m_Name: BackStab Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &6389220526639570984
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526639570980}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.43480468, y: 0.73867637, z: 0.0037221909}
-  m_Center: {x: -0.0020707846, y: -0.03268376, z: 0.084769726}
---- !u!54 &6389220526639570985
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526639570980}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!4 &6389220526639570987
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526639570980}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.2, z: -0.3}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220526931123927}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6389220526643944728
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526643944730}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 638c66c7461e90a40a10af78dc3b9e73, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  combatStanceState: {fileID: 6389220527889128876}
-  rotateTowardsTargetState: {fileID: 9164903153475300613}
-  deadState: {fileID: 1987981445}
---- !u!4 &6389220526643944729
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526643944730}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220526643944730
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526643944729}
-  - component: {fileID: 6389220526643944728}
-  m_Layer: 9
-  m_Name: Pursue Target State
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6389220526657713144
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526657713145}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220526657713145
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526657713144}
-  - component: {fileID: 6389220526657713151}
-  m_Layer: 9
-  m_Name: Ambush State
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &6389220526657713151
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526657713145}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 29d6dcda7e2b6b34cafdbdddabdfd259, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isSleeping: 1
-  detectionRadius: 2
-  sleepAnimation: Sleeping
-  wakeAnimation: Getting Up
-  detectionLayer:
-    serializedVersion: 2
-    m_Bits: 2048
-  pursueTargetState: {fileID: 6389220526643944728}
---- !u!114 &6389220526692870798
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8863944021803279523}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47d4cfcd17f34e744bb8fdb2ac78c47b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentOverride: {fileID: 9051282064442343688}
-  isLeftHandSlot: 1
-  isRightHandSlot: 0
-  isBackSlot: 0
-  currentWeapon: {fileID: 0}
-  currentWeaponModel: {fileID: 0}
---- !u!1 &6389220526931123920
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526931123927}
-  m_Layer: 9
-  m_Name: Combat Colliders
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6389220526931123927
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526931123920}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6389220527317443136}
-  - {fileID: 6389220526639570987}
-  - {fileID: 7294614000073953865}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!222 &6389220526957520224
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526957520227}
-  m_CullTransparentMesh: 1
---- !u!114 &6389220526957520225
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526957520227}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!224 &6389220526957520226
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526957520227}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4436255636332385971}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6389220526957520227
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220526957520226}
-  - component: {fileID: 6389220526957520224}
-  - component: {fileID: 6389220526957520225}
-  m_Layer: 5
-  m_Name: HealthBarBackground
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &6389220527282679362
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1251083813410915910}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47d4cfcd17f34e744bb8fdb2ac78c47b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentOverride: {fileID: 6282815699825232000}
-  isLeftHandSlot: 0
-  isRightHandSlot: 1
-  isBackSlot: 0
-  currentWeapon: {fileID: 0}
-  currentWeaponModel: {fileID: 0}
---- !u!4 &6389220527317443136
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527317443137}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220526931123927}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220527317443137
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527317443136}
-  - component: {fileID: 6389220527317443142}
-  - component: {fileID: 6389220527317443143}
-  m_Layer: 10
-  m_Name: Character Collider Blocker
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!54 &6389220527317443142
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527317443137}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!136 &6389220527317443143
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527317443137}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.45
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 1, z: 0}
---- !u!114 &6389220527422649730
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 33d3e019774199448a540bbafd9bb8eb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveDirection: {x: 0, y: 0, z: 0}
-  groundLayer:
-    serializedVersion: 2
-    m_Bits: 0
-  inAirTimer: 0
-  yVelocity: {x: 0, y: 0, z: 0}
-  groundedYVelocity: -20
-  fallStartYVelocity: -7
-  gravityForce: -25
-  groundCheckSphereRadius: 0
-  detectionLayer:
-    serializedVersion: 2
-    m_Bits: 0
---- !u!114 &6389220527422649759
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c9236ad839a2af418234fdcfc9cbad4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  characterController: {fileID: 0}
-  anim: {fileID: 0}
-  characterAnimatorManager: {fileID: 0}
-  characterWeaponSlotManager: {fileID: 0}
-  characterNetworkManager: {fileID: 0}
-  lockOnTransform: {fileID: 6389220527869462209}
-  backStabCollider: {fileID: 7294613999552322113}
-  riposteCollider: {fileID: 7294614000073953864}
-  canTalk: 0
-  isInteracting: 0
-  canBeRiposted: 0
-  canBeParried: 0
-  isParrying: 0
-  isBlocking: 0
-  isInvulnerable: 0
-  canDoCombo: 0
-  isUsingRightHand: 0
-  isUsingLeftHand: 0
-  isGrabbed: 0
-  isRotatingWithRootMotion: 0
-  canRotate: 0
-  isInAir: 0
-  isGrounded: 0
-  isTwoHandingWeapon: 0
-  isClimbing: 0
-  isMoving: 0
-  isFiringSpell: 0
-  pendingCriticalDamage: 0
-  currentState: {fileID: 6389220526372162101}
-  currentTarget: {fileID: 0}
-  navMeshAgent: {fileID: 0}
-  enemyRigidbody: {fileID: 0}
-  rotationSpeed: 15
-  maximumAggroRadius: 2
-  detectionRadius: 10
-  maximumDetectionAngle: 50
-  minimumDetectionAngle: -50
-  currentRecoveryTime: 0
-  allowAIToPerformCombos: 1
-  isPhaseShifting: 0
-  comboLikelyHood: 50
---- !u!224 &6389220527647780841
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527647780842}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6389220527793417461}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6389220527647780842
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527647780841}
-  - component: {fileID: 6389220527647780846}
-  - component: {fileID: 6389220527647780847}
-  m_Layer: 9
-  m_Name: UI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!223 &6389220527647780846
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527647780842}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &6389220527647780847
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527647780842}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
---- !u!1 &6389220527720015972
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527720015979}
-  - component: {fileID: 6389220527720015977}
-  - component: {fileID: 6389220527720015978}
-  m_Layer: 5
-  m_Name: HealthBarFill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!222 &6389220527720015977
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527720015972}
-  m_CullTransparentMesh: 1
---- !u!114 &6389220527720015978
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527720015972}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.78431374, g: 0.003648994, b: 0.003648994, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!224 &6389220527720015979
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527720015972}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4436255636332385971}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &6389220527793417460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527793417462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 307058f48fb8a9448b4494f3e2b3509f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &6389220527793417461
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527793417462}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4436255636332385971}
-  m_Father: {fileID: 6389220527647780841}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6389220527793417462
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527793417461}
-  - component: {fileID: 6389220527793417460}
-  m_Layer: 9
-  m_Name: HealthBar
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6389220527865628190
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527865628191}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.05, y: 0, z: -0.75}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220526242444112}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220527865628191
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527865628190}
-  m_Layer: 9
-  m_Name: Back Stabber Standing Point
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6389220527869295477
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527869295478}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6389220526657713144}
-  - {fileID: 6389220526372162102}
-  - {fileID: 6389220526643944729}
-  - {fileID: 6389220527889128877}
-  - {fileID: 6389220526286626679}
-  - {fileID: 9164903153475300612}
-  - {fileID: 1987981446}
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220527869295478
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527869295477}
-  m_Layer: 9
-  m_Name: Enemy States
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6389220527869462209
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527869462210}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5324564050113085470}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220527869462210
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527869462209}
-  - component: {fileID: 2853968160758623339}
-  m_Layer: 9
-  m_Name: Lock On Transform
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &6389220527889128876
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527889128878}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4169a915cedfd1b4fb2c42fed43ad18a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  attackState: {fileID: 6389220526286626678}
-  enemyAttacks:
-  - {fileID: 11400000, guid: 12b6f39ee5c982244af284ea102c8a17, type: 2}
-  - {fileID: 11400000, guid: 714b0ac9bb0c6a84f80addfe12aca049, type: 2}
-  pursueTargetState: {fileID: 6389220526643944728}
-  deadState: {fileID: 1987981445}
---- !u!4 &6389220527889128877
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220527889128878}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6389220527889128878
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6389220527889128877}
-  - component: {fileID: 6389220527889128876}
-  m_Layer: 9
-  m_Name: Combat Stance State
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6395542511505196933
 GameObject:
   m_ObjectHideFlags: 0
@@ -54419,22 +51674,6 @@ Transform:
   m_Father: {fileID: 1828601865934362899}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6408564107096017747
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1719699630006140884}
-  m_Layer: 9
-  m_Name: Head_Attachment
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6432437047733378677
 GameObject:
   m_ObjectHideFlags: 0
@@ -54456,22 +51695,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6078572700425843555, guid: 6b257debfeb0abb40b533d51037425cf, type: 3}
   m_PrefabInstance: {fileID: 999547179008513038}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &6462886351047640612
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5221542145887107602}
-  m_Layer: 9
-  m_Name: Thumb_03_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6463470215322706281
 GameObject:
   m_ObjectHideFlags: 0
@@ -54536,22 +51759,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &6521956822721154984
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 188774370174377083}
-  m_Layer: 9
-  m_Name: Clavicle_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6534604300407296102
 GameObject:
   m_ObjectHideFlags: 0
@@ -54568,22 +51775,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6557065754621394893
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6909935022097538416}
-  m_LocalRotation: {x: -0.0644364, y: -0.20452474, z: 0.01937257, w: 0.9765461}
-  m_LocalPosition: {x: -0.06370216, y: -0.00000005029142, z: -0.000000009313226}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5221542145887107602}
-  m_Father: {fileID: 6082085879450899395}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6563853834820523177
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -54592,52 +51783,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5325303215150246062}
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &6581110072837808292
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3260685853615109565}
-  m_Layer: 9
-  m_Name: UpperLeg_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6597885023117375245
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1322399583730087400}
-  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
-  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6664765756323621352
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5402367105864248868}
-  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
-  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &6676619450791543102
 Transform:
   m_ObjectHideFlags: 0
@@ -54653,22 +51798,6 @@ Transform:
   m_Father: {fileID: 5139807438615400398}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6696321633947742390
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6960020069865799606}
-  m_Layer: 9
-  m_Name: Tome_Attachment_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!137 &6708454286465928761
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
@@ -54768,22 +51897,6 @@ SkinnedMeshRenderer:
     m_Center: {x: 0.02152279, y: -0.009413511, z: 0}
     m_Extent: {x: 0.9414129, y: 0.2786869, z: 1.0245608}
   m_DirtyAABB: 0
---- !u!4 &6749191471678442243
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5318091681825837757}
-  m_LocalRotation: {x: 0.30367216, y: 0.20954996, z: 0.46115452, w: 0.80697495}
-  m_LocalPosition: {x: -0.13197872, y: 0.000000040818122, z: -0.0000000069849193}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3580520178660990945}
-  m_Father: {fileID: 5932876856517045203}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6758379288198491351
 GameObject:
   m_ObjectHideFlags: 0
@@ -54846,6 +51959,8 @@ MonoBehaviour:
   currentFocus: 0
   soulCount: 0
   isBoss: 1
+  currentEquipLoad: 0
+  maxEquipLoad: 0
   totalPoiseDefense: 0
   offensivePoiseBonus: 0
   armorPoiseBonus: 100
@@ -54902,9 +52017,6 @@ MonoBehaviour:
   fallStartYVelocity: -7
   gravityForce: -25
   groundCheckSphereRadius: 0
-  detectionLayer:
-    serializedVersion: 2
-    m_Bits: 0
 --- !u!114 &6777079784069156016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -54918,7 +52030,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterController: {fileID: 0}
-  anim: {fileID: 0}
+  animator: {fileID: 0}
   characterAnimatorManager: {fileID: 0}
   characterWeaponSlotManager: {fileID: 0}
   characterNetworkManager: {fileID: 0}
@@ -54938,7 +52050,6 @@ MonoBehaviour:
   isGrabbed: 0
   isRotatingWithRootMotion: 0
   canRotate: 0
-  isInAir: 0
   isGrounded: 0
   isTwoHandingWeapon: 0
   isClimbing: 0
@@ -54948,7 +52059,6 @@ MonoBehaviour:
   currentState: {fileID: 2173030237260673505}
   currentTarget: {fileID: 0}
   navMeshAgent: {fileID: 0}
-  enemyRigidbody: {fileID: 0}
   rotationSpeed: 15
   maximumAggroRadius: 3
   detectionRadius: 10
@@ -55135,38 +52245,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &6890761910560796752
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1351055107741937949}
-  m_Layer: 9
-  m_Name: Spine_03
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &6909935022097538416
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6557065754621394893}
-  m_Layer: 9
-  m_Name: Thumb_02_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &6926966846658439280
 Transform:
   m_ObjectHideFlags: 0
@@ -55185,84 +52263,6 @@ Transform:
   - {fileID: 2356641612915200278}
   m_Father: {fileID: 7934333167194171372}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6936919367508955919
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7190498677465165007}
-  m_LocalRotation: {x: 0.042210087, y: 0.0030954692, z: -0.30917105, w: -0.95006424}
-  m_LocalPosition: {x: 0.040935885, y: 0.00000092282426, z: -0.000000056810677}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3069193874456748922}
-  m_Father: {fileID: 973694463337861414}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &6960020069865799606
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6696321633947742390}
-  m_LocalRotation: {x: 0, y: 0, z: 3.330669e-16, w: 1}
-  m_LocalPosition: {x: -1.4210854e-16, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6971371313033549019
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7045894727690539837}
-  m_Layer: 9
-  m_Name: Thumb_02_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6981905998638309523
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2546708163793699346}
-  m_LocalRotation: {x: -0.46113664, y: 0.5360532, z: 0.46113664, w: 0.5360532}
-  m_LocalPosition: {x: -1.4210854e-16, y: 8.8817837e-17, z: 9.666941e-20}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2783984255777969060}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7045894727690539837
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6971371313033549019}
-  m_LocalRotation: {x: 0.06596402, y: 0.15778397, z: -0.019527182, w: -0.98507446}
-  m_LocalPosition: {x: 0.06370147, y: -0.000007788651, z: 0.0000004246831}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2567597172372777715}
-  m_Father: {fileID: 2903460674201690944}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &7082014763218354896
 Transform:
@@ -55311,22 +52311,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &7128807778816943711
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8671589710391629568}
-  m_Layer: 9
-  m_Name: IndexFinger_01_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &7142631609926136081
 GameObject:
   m_ObjectHideFlags: 0
@@ -55338,38 +52322,6 @@ GameObject:
   - component: {fileID: 5186356157424572691}
   m_Layer: 9
   m_Name: Head
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7144434199710357051
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 983888367037084498}
-  m_Layer: 9
-  m_Name: Prop_Attachment_Extra2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7190498677465165007
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6936919367508955919}
-  m_Layer: 9
-  m_Name: IndexFinger_02_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -55390,23 +52342,6 @@ Transform:
   m_Father: {fileID: 5124598197592536346}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7202887979638949049
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6175693759045611578}
-  - component: {fileID: 113127646290131704}
-  m_Layer: 9
-  m_Name: Model
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &7206060803414996579
 Transform:
   m_ObjectHideFlags: 0
@@ -55437,142 +52372,6 @@ Transform:
   m_Father: {fileID: 2831425681351256297}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7294613998697194322
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7294613998697194323}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.05, y: 0, z: 0.75}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220526242444112}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7294613998697194323
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7294613998697194322}
-  m_Layer: 9
-  m_Name: Riposter Standing Point
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &7294613999552322113
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6389220526639570980}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  criticalDamagerStandPosition: {fileID: 6389220527865628190}
---- !u!114 &7294614000073953864
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7294614000073953870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a85e5f5020917f54b847390123a91477, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  criticalDamagerStandPosition: {fileID: 7294613998697194322}
---- !u!4 &7294614000073953865
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7294614000073953870}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.2, z: 0.3}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220526931123927}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &7294614000073953866
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7294614000073953870}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!65 &7294614000073953867
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7294614000073953870}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.43480468, y: 0.73867637, z: 0.19620275}
-  m_Center: {x: -0.0020707846, y: -0.03268376, z: -0.011470556}
---- !u!1 &7294614000073953870
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7294614000073953865}
-  - component: {fileID: 7294614000073953866}
-  - component: {fileID: 7294614000073953867}
-  - component: {fileID: 7294614000073953864}
-  m_Layer: 13
-  m_Name: Riposte Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7304826047865599955
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4819955728311668068}
-  m_Layer: 9
-  m_Name: Toes_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &7337644585278257606
 GameObject:
   m_ObjectHideFlags: 0
@@ -55636,54 +52435,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7365439574029380290
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1168657437883747327}
-  m_LocalRotation: {x: 0.056999438, y: 0.7304186, z: -0.6803029, w: -0.020682381}
-  m_LocalPosition: {x: 0.041157685, y: -0.026920708, z: -0.09896705}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5499146885587411047}
-  m_Father: {fileID: 2783984255777969060}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7375749217189888505
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1183721638923940508}
-  m_Layer: 9
-  m_Name: Finger_02_R
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7387542382376720086
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2942299695292835564}
-  m_Layer: 9
-  m_Name: Finger_03_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &7396545738978568052
 GameObject:
   m_ObjectHideFlags: 0
@@ -55716,38 +52467,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7462824495301902313
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9189510629761655047}
-  m_LocalRotation: {x: -0.04422331, y: -0.022021903, z: 0.15719514, w: 0.98633116}
-  m_LocalPosition: {x: -0.037911892, y: 0.00000000376167, z: -0.0000000028667273}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5998905013868159310}
-  m_Father: {fileID: 7514345698659232330}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7514345698659232330
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5117910844063252522}
-  m_LocalRotation: {x: -0.042240687, y: -0.0028564357, z: 0.31329337, w: 0.9487123}
-  m_LocalPosition: {x: -0.040936317, y: 0.000000037285645, z: -3.0195224e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7462824495301902313}
-  m_Father: {fileID: 8671589710391629568}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7536372904693601063
 GameObject:
   m_ObjectHideFlags: 0
@@ -55764,37 +52483,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7551236085092406015
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7773628815490034650}
-  m_LocalRotation: {x: 0.87222844, y: 0.47165158, z: 0.032174, w: -0.1254083}
-  m_LocalPosition: {x: 0.3771233, y: 0.00000014901161, z: -0.0000008530915}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2077808291976089077}
-  m_Father: {fileID: 8385787491082885542}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7604200603854571016
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2030180832677899186}
-  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2927160198095412280}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &7643215381980476071
 Transform:
   m_ObjectHideFlags: 0
@@ -55810,22 +52498,6 @@ Transform:
   - {fileID: 5124598197592536346}
   m_Father: {fileID: 6127100004860402792}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7717444924548114404
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6233126484941713693}
-  m_LocalRotation: {x: 0.99508506, y: -0.098823294, z: 0.0062347334, w: -0.0009606643}
-  m_LocalPosition: {x: -0.10393268, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6293304847458540895}
-  m_Father: {fileID: 2783984255777969060}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &7765188485912743529
 Transform:
@@ -55843,22 +52515,6 @@ Transform:
   m_Father: {fileID: 6926966846658439280}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &7773628815490034650
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7551236085092406015}
-  m_Layer: 9
-  m_Name: Ankle_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &7788063897220176046
 Transform:
   m_ObjectHideFlags: 0
@@ -55886,38 +52542,6 @@ GameObject:
   - component: {fileID: 5139807438615400398}
   m_Layer: 9
   m_Name: Root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7819668629950243218
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2077808291976089077}
-  m_Layer: 9
-  m_Name: Ball_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7825207731729437430
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5675170240245011131}
-  m_Layer: 9
-  m_Name: IndexFinger_04_R
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -55990,22 +52614,6 @@ Transform:
   - {fileID: 8148123825577489773}
   - {fileID: 8653251758179855394}
   m_Father: {fileID: 4551045965240172973}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7977729983871090516
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6206293677396084738}
-  m_LocalRotation: {x: 0.27298498, y: 0.16956079, z: 0.46912387, w: 0.82258815}
-  m_LocalPosition: {x: 0.1319786, y: 0.0000065022614, z: 0.000000037252903}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5672531335148800765}
-  m_Father: {fileID: 188774370174377083}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &7982664780069296276
@@ -56267,22 +52875,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8385787491082885542
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330335877044071151}
-  m_LocalRotation: {x: 0.6410804, y: 0.065192334, z: -0.04350663, w: 0.7634613}
-  m_LocalPosition: {x: 0.39930925, y: -0.00000035762787, z: -1.2739676e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7551236085092406015}
-  m_Father: {fileID: 3260685853615109565}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8395479912287044853
 GameObject:
   m_ObjectHideFlags: 0
@@ -56299,53 +52891,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &8437631042699648935
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5828659720317751899}
-  m_Layer: 9
-  m_Name: Neck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8480182534368302927
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3603312035634020129}
-  m_LocalRotation: {x: 0.8367191, y: 0.51112205, z: 0.121969916, w: -0.15420388}
-  m_LocalPosition: {x: -0.37712362, y: 0.00000008940697, z: -0.0000000055879354}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8551034585152293605}
-  m_Father: {fileID: 5499146885587411047}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &8490854622526040569
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2200862012189808596}
-  m_LocalRotation: {x: 0.01664637, y: 0.096525334, z: -0.16913006, w: 0.98071444}
-  m_LocalPosition: {x: 0.03003113, y: 0.0000011334713, z: 0.0000003591099}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5012670288610550331}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &8493846468309117212
 Transform:
   m_ObjectHideFlags: 0
@@ -56508,22 +53053,6 @@ SkinnedMeshRenderer:
     m_Center: {x: 0.02152279, y: -0.009413511, z: 0}
     m_Extent: {x: 0.9414129, y: 0.2786869, z: 1.0245608}
   m_DirtyAABB: 0
---- !u!4 &8551034585152293605
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2380868480718890050}
-  m_LocalRotation: {x: -0, y: -0, z: -0.2700158, w: 0.96285594}
-  m_LocalPosition: {x: -0.1128404, y: 0.000000007450581, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3973040660317438724}
-  m_Father: {fileID: 8480182534368302927}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &8589390791563158581
 Transform:
   m_ObjectHideFlags: 0
@@ -56554,22 +53083,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7976307229090525489}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &8671589710391629568
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7128807778816943711}
-  m_LocalRotation: {x: -0.001012347, y: -0.07592192, z: -0.010044581, w: 0.99706274}
-  m_LocalPosition: {x: -0.1039656, y: 0.003987163, z: 0.026726495}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7514345698659232330}
-  m_Father: {fileID: 9051282064442343688}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8676724304500223669
 GameObject:
@@ -56667,23 +53180,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &8863944021803279523
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9051282064442343688}
-  - component: {fileID: 6389220526692870798}
-  m_Layer: 9
-  m_Name: Hand_L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &8881965764105017339
 Transform:
   m_ObjectHideFlags: 0
@@ -56766,154 +53262,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &9051282064442343688
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8863944021803279523}
-  m_LocalRotation: {x: -0.1824338, y: -0.019140687, z: -0.06826788, w: 0.98065853}
-  m_LocalPosition: {x: -0.2711453, y: -0.000000011197699, z: -0.00038136943}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4236985576475643806}
-  - {fileID: 8671589710391629568}
-  - {fileID: 6597885023117375245}
-  - {fileID: 6664765756323621352}
-  - {fileID: 6082085879450899395}
-  - {fileID: 6960020069865799606}
-  m_Father: {fileID: 3580520178660990945}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &9058321785823695558
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b3ed6b924acef144097847a59bee8a07, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  teamIDNumber: 1
-  soulsAwardedOnDeath: 0
-  healthLevel: 10
-  maxHealth: 0
-  currentHealth: 0
-  staminaLevel: 10
-  maxStamina: 0
-  currentStamina: 0
-  focusLevel: 10
-  maxFocus: 0
-  currentFocus: 0
-  soulCount: 0
-  isBoss: 0
-  totalPoiseDefense: 0
-  offensivePoiseBonus: 0
-  armorPoiseBonus: 40
-  totalPoiseResetTime: 3
-  poiseResetTimer: 0
-  isStuned: 0
-  physicalDamageAbsorptionHead: 0
-  physicalDamageAbsorptionBody: 0
-  physicalDamageAbsorptionLegs: 0
-  physicalDamageAbsorptionHands: 0
-  totalPhysicalDamageAbsorption: 0
-  fireDamageAbsorptionHead: 0
-  fireDamageAbsorptionBody: 0
-  fireDamageAbsorptionLegs: 0
-  fireDamageAbsorptionHands: 0
-  totalFireDamageAbsorption: 0
-  isDead: 0
-  enemyLocomotionManager: {fileID: 0}
-  enemyHealthBar: {fileID: 6389220527793417460}
-  worldEventManager: {fileID: 0}
---- !u!114 &9058321785823695559
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ab93e3ab23f8a63499317d9481939fd5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightWeaponFX: {fileID: 0}
-  leftWeaponFX: {fileID: 0}
-  bloodSplatterFX: {fileID: 414520594313402191, guid: c8e9dc9f48c523a4ba94345b65e4758c, type: 3}
-  defaultPoisonedParticleFX: {fileID: 6036021610362047377, guid: c59dddb4847201d4bbc6dfdf30c1748d, type: 3}
-  currentPoisonedParticleFX: {fileID: 0}
-  buildUpTransform: {fileID: 0}
-  isPoisoned: 0
-  poisonBuildUp: 0
-  poisonAmount: 100
-  defaultPoisonAmount: 0
-  poisonDamage: 0
-  poisonTimer: 2
---- !u!114 &9058321785823695560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d19325047f5d10b449b1d7aabcf54c7d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  currentSpell: {fileID: 0}
-  rightWeapon: {fileID: 0}
-  leftWeapon: {fileID: 0}
-  currentConsumable: {fileID: 0}
-  memorizedSpells:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  selectedConsumables:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  weaponsInLeftHandSlots:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  weaponsInRightHandSlots:
-  - {fileID: 11400000, guid: 311163681efcd6b428e73397bf9f5144, type: 2}
-  - {fileID: 0}
-  - {fileID: 0}
-  currentHelmetEquipment: {fileID: 0}
-  currentTorsoEquipment: {fileID: 0}
-  currentLegEquipment: {fileID: 0}
-  currentGuntletEquipment: {fileID: 0}
-  currentRightWeaponIndex: 0
-  currentLeftWeaponIndex: 0
-  currentSpellIndex: 0
-  currentConsumableIndex: 0
---- !u!114 &9058321785823695561
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5324564050113085441}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RigLayers:
-  - m_Rig: {fileID: 1744594462}
-    m_Active: 1
-  m_Effectors: []
 --- !u!1 &9060488725244164377
 GameObject:
   m_ObjectHideFlags: 0
@@ -56979,52 +53327,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &9164903153475300611
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9164903153475300612}
-  - component: {fileID: 9164903153475300613}
-  m_Layer: 9
-  m_Name: RotateTowardsTargetState
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &9164903153475300612
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9164903153475300611}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6389220527869295477}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &9164903153475300613
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9164903153475300611}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: faf3ab124fae898429ca1c40629fb0e1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  combatStanceState: {fileID: 6389220527889128876}
-  pursueTargetState: {fileID: 0}
 --- !u!1 &9185453235444934190
 GameObject:
   m_ObjectHideFlags: 0
@@ -57036,22 +53338,6 @@ GameObject:
   - component: {fileID: 5289950539484381266}
   m_Layer: 9
   m_Name: Hips
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &9189510629761655047
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7462824495301902313}
-  m_Layer: 9
-  m_Name: IndexFinger_03_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/AI/Enemy/Manager/EnemyAnimatorManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/EnemyAnimatorManager.cs
@@ -34,8 +34,6 @@ namespace SoulsLike {
         }
 
         public override void OnAnimatorMove() {
-            if (character.isInteracting == false) return;
-
             Vector3 velocity = character.animator.deltaPosition;
             character.characterController.Move(velocity);
 

--- a/Assets/Scripts/AI/Enemy/Manager/EnemyLocomotionManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/EnemyLocomotionManager.cs
@@ -5,7 +5,6 @@ using UnityEngine.AI;
 
 namespace SoulsLike {
     public class EnemyLocomotionManager : CharacterLocomotionManager {
-
         #region 리지드 바디를 사용할 경우
         //public CapsuleCollider characterCollider;
         //public CapsuleCollider characterColliderBlocker;
@@ -14,5 +13,17 @@ namespace SoulsLike {
         //    Physics.IgnoreCollision(characterCollider, characterColliderBlocker, true);
         //}
         #endregion
+
+        protected override void Awake() {
+            base.Awake();
+        }
+
+        protected override void Start() {
+            base.Start();
+        }
+
+        protected override void Update() {
+            base.Update();
+        }
     }
 }

--- a/Assets/Scripts/AI/Enemy/Manager/EnemyManager.cs
+++ b/Assets/Scripts/AI/Enemy/Manager/EnemyManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.AI;
 namespace SoulsLike {
     public class EnemyManager : CharacterManager {
+        
         EnemyAnimatorManager enemyAnimatorManager;
         EnemyStatsManager enemyStatsManager;
         EnemyEffectsManager enemyEffectsManager;
@@ -11,7 +12,7 @@ namespace SoulsLike {
         public State currentState;
         public CharacterStatsManager currentTarget;
         public NavMeshAgent navMeshAgent;
-        public Rigidbody enemyRigidbody;
+        //public Rigidbody enemyRigidbody;
 
         public float rotationSpeed = 15;
         public float maximumAggroRadius = 1.5f; // 공격 가능 사거리
@@ -33,13 +34,11 @@ namespace SoulsLike {
             enemyStatsManager = GetComponent<EnemyStatsManager>();
             enemyEffectsManager = GetComponent<EnemyEffectsManager>();
             navMeshAgent = GetComponentInChildren<NavMeshAgent>();
-            enemyRigidbody = GetComponent<Rigidbody>();
             navMeshAgent.enabled = false;
             navMeshAgent.updateRotation = false;
         }
 
         private void Start() {
-            enemyRigidbody.isKinematic = false;
         }
 
         protected override void Update() {

--- a/Assets/Scripts/AI/Enemy/States/DeadState.cs
+++ b/Assets/Scripts/AI/Enemy/States/DeadState.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 namespace SoulsLike {
     public class DeadState : State {
         public override State Tick(EnemyManager enemyManager, EnemyStatsManager enemyStats, EnemyAnimatorManager enemyAnimatorManager) {
-            enemyManager.enemyRigidbody.isKinematic = false;
-            enemyManager.enemyRigidbody.useGravity = false;
+            //enemyManager.enemyRigidbody.isKinematic = false;
+            //enemyManager.enemyRigidbody.useGravity = false;
             //enemyStats.enemyLocomotionManager.characterCollider.enabled = false;
             enemyManager.navMeshAgent.enabled = false;
             return this;

--- a/Assets/Scripts/CharacterLocomotionManager.cs
+++ b/Assets/Scripts/CharacterLocomotionManager.cs
@@ -23,6 +23,7 @@ namespace SoulsLike {
         }
 
         protected virtual void Start() {
+
         }
 
         protected virtual void Update() {

--- a/Assets/Scripts/CharacterNetworkManager.cs
+++ b/Assets/Scripts/CharacterNetworkManager.cs
@@ -7,56 +7,60 @@ namespace SoulsLike {
     public class CharacterNetworkManager : NetworkBehaviour {
 
         CharacterManager character;
-        // ¿¬°áµÇ¾î ÀÖ´Â ¿ÀºêÁ§Æ®ÀÇ ¿ùµå ÁÂÇ¥¿Í È¸Àü°ªÀ» ±¸ÇÔ
+        // ì—°ê²°ë˜ì–´ ìˆëŠ” ì˜¤ë¸Œì íŠ¸ì˜ ì›”ë“œ ì¢Œí‘œì™€ íšŒì „ê°’ì„ êµ¬í•¨
         [Header("Network Position")]
-        // ³×Æ®¿öÅ© »óÀÇ ÁÂÇ¥´Â Á¢¼ÓÇØ ÀÖ´Â ¸ğµç »ç¶÷ÀÌ ÀĞÀ» ¼ö ÀÖ°í, ÁÖÀÎ¸¸ÀÌ ¼öÁ¤°¡´É
+        // ë„¤íŠ¸ì›Œí¬ ìƒì˜ ì¢Œí‘œëŠ” ì ‘ì†í•´ ìˆëŠ” ëª¨ë“  ì‚¬ëŒì´ ì½ì„ ìˆ˜ ìˆê³ , ì£¼ì¸ë§Œì´ ìˆ˜ì •ê°€ëŠ¥
         public NetworkVariable<Vector3> networkPosition = new NetworkVariable<Vector3>(Vector3.zero, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public Vector3 networkVelocity;
-        public float networkPositionSmoothTime = 0.1f; // ¾ó¸¶³ª ºü¸£°Ô ½ÇÁ¦ À§Ä¡°¡ ³×Æ®¿öÅ© »óÀ¸·Î ¹İ¿µµÉÁö, °ªÀÌ Ä¿Áú¼ö·Ï ´À¸®°Ô ¹İ¿µµÇ¾î ¸¶Ä¡ ¼ø°£ÀÌµ¿ ÇÏ´Â°Í Ã³·³ ÀÌµ¿
+        public float networkPositionSmoothTime = 0.1f; // ì–¼ë§ˆë‚˜ ë¹ ë¥´ê²Œ ì‹¤ì œ ìœ„ì¹˜ê°€ ë„¤íŠ¸ì›Œí¬ ìƒìœ¼ë¡œ ë°˜ì˜ë ì§€, ê°’ì´ ì»¤ì§ˆìˆ˜ë¡ ëŠë¦¬ê²Œ ë°˜ì˜ë˜ì–´ ë§ˆì¹˜ ìˆœê°„ì´ë™ í•˜ëŠ”ê²ƒ ì²˜ëŸ¼ ì´ë™
         public NetworkVariable<Quaternion> networkRotation = new NetworkVariable<Quaternion>(Quaternion.identity, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public float networkRotationSmoothTime = 0.1f;
 
-        // °ÔÀÓ¿ÀºêÁ§Æ®ÀÇ ÁÖÀÎÀÌ¶ó¸é ³» ¿ÀºêÁ§Æ®ÀÇ °ªµéÀ» ³×Æ®¿öÅ© º¯¼öµé¿¡ ÇÒ´ç
-        // ÁÖÀÎÀÌ ¾Æ´Ï¶ó¸é ³×Æ®¿öÅ© °ªµé¿¡¼­ °¡Á®¿Í ÇÒ´çÇÑ´Ù.
-        // ´©±º°¡ÀÇ °ÔÀÓ¿¡ ÇÕ·ùÇß´Ù¸é, ´©±º°¡ÀÇ °ÔÀÓ³»¿¡¼­ ³ªÀÇ ¿ÀºêÁ§Æ®´Â ³×Æ®¿öÅ©·ÎºÎÅÍ °ªµéÀ» °¡Á®¿Í ´ëÀÔ¹ŞÀ½
-        // ³×Æ®¿öÅ©¿¡ Á¸ÀçÇÏ´Â °ªµéÀº ³» °ÔÀÓ¿¡¼­ ³ªÀÇ ¿ÀºêÁ§Æ®·ÎºÎÅÍ °ªÀ» ÇÒ´ç¹ŞÀº °Í
+        // ê²Œì„ì˜¤ë¸Œì íŠ¸ì˜ ì£¼ì¸ì´ë¼ë©´ ë‚´ ì˜¤ë¸Œì íŠ¸ì˜ ê°’ë“¤ì„ ë„¤íŠ¸ì›Œí¬ ë³€ìˆ˜ë“¤ì— í• ë‹¹
+        // ì£¼ì¸ì´ ì•„ë‹ˆë¼ë©´ ë„¤íŠ¸ì›Œí¬ ê°’ë“¤ì—ì„œ ê°€ì ¸ì™€ í• ë‹¹í•œë‹¤.
+        // ëˆ„êµ°ê°€ì˜ ê²Œì„ì— í•©ë¥˜í–ˆë‹¤ë©´, ëˆ„êµ°ê°€ì˜ ê²Œì„ë‚´ì—ì„œ ë‚˜ì˜ ì˜¤ë¸Œì íŠ¸ëŠ” ë„¤íŠ¸ì›Œí¬ë¡œë¶€í„° ê°’ë“¤ì„ ê°€ì ¸ì™€ ëŒ€ì…ë°›ìŒ
+        // ë„¤íŠ¸ì›Œí¬ì— ì¡´ì¬í•˜ëŠ” ê°’ë“¤ì€ ë‚´ ê²Œì„ì—ì„œ ë‚˜ì˜ ì˜¤ë¸Œì íŠ¸ë¡œë¶€í„° ê°’ì„ í• ë‹¹ë°›ì€ ê²ƒ
         [Header("Network Movement Animation")]
         public NetworkVariable<float> verticalNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public NetworkVariable<float> horizontalNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public NetworkVariable<float> moveAmountNetworkMovement = new NetworkVariable<float>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
-        // sprintFlag ¿Í lockOnFlag ´ëÃ¼ (³» °æ¿ì »ç´Ù¸®¸¦ ¿À¸£³»¸±¶§ÀÇ ºí·»µå Æ®¸®°¡ µû·Î ÀÖ¾î¼­ Ãß°¡ÇØÁà¾ß ÇÒµí)
-        // ±âº»ÀûÀ¸·Î´Â °ÔÀÓ³»ÀÇ ¾î¶² ´Ù¸¥ »ç¶÷ÀÌ ³» °ÔÀÓÀÇ Æ¯Á¤ ½ºÅ©¸³Æ®¿¡¼­ Æ¯Á¤ º¯¼ö°¡ º¯°æµÇ´Â°ÍÀ» ¾Ë¾Æ³¾ ¹æ¹ıÀÌ ¾øÀ½
-        // ÇÏÁö¸¸ ³×Æ®¿öÅ© º¯¼ö´Â ÇÑÂÊ¿¡¼­ º¯°æµÉ ¶§¸¶´Ù ¸ğµç Å¬¶óÀÌ¾ğÆ®µé¿¡ ´ëÇØ º¯°æµÇ±â ¶§¹®¿¡ sprintFlag ¿Í lockOnFlag¸¦ ³×Æ®¿öÅ© º¯¼ö·Î ¸¸µé¾î »ç¿ë
+        // sprintFlag ì™€ lockOnFlag ëŒ€ì²´ (ë‚´ ê²½ìš° ì‚¬ë‹¤ë¦¬ë¥¼ ì˜¤ë¥´ë‚´ë¦´ë•Œì˜ ë¸”ë Œë“œ íŠ¸ë¦¬ê°€ ë”°ë¡œ ìˆì–´ì„œ ì¶”ê°€í•´ì¤˜ì•¼ í• ë“¯)
+        // ê¸°ë³¸ì ìœ¼ë¡œëŠ” ê²Œì„ë‚´ì˜ ì–´ë–¤ ë‹¤ë¥¸ ì‚¬ëŒì´ ë‚´ ê²Œì„ì˜ íŠ¹ì • ìŠ¤í¬ë¦½íŠ¸ì—ì„œ íŠ¹ì • ë³€ìˆ˜ê°€ ë³€ê²½ë˜ëŠ”ê²ƒì„ ì•Œì•„ë‚¼ ë°©ë²•ì´ ì—†ìŒ
+        // í•˜ì§€ë§Œ ë„¤íŠ¸ì›Œí¬ ë³€ìˆ˜ëŠ” í•œìª½ì—ì„œ ë³€ê²½ë  ë•Œë§ˆë‹¤ ëª¨ë“  í´ë¼ì´ì–¸íŠ¸ë“¤ì— ëŒ€í•´ ë³€ê²½ë˜ê¸° ë•Œë¬¸ì— sprintFlag ì™€ lockOnFlagë¥¼ ë„¤íŠ¸ì›Œí¬ ë³€ìˆ˜ë¡œ ë§Œë“¤ì–´ ì‚¬ìš©
         [Header("Flags")]
         public NetworkVariable<bool> isSprinting = new NetworkVariable<bool>(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public NetworkVariable<bool> isLockedOn = new NetworkVariable<bool>(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+
+        [Header("Equipment")]
+        public NetworkVariable<int> currentRightWeaponID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<int> currentLeftWeaponID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
         protected virtual void Awake() {
             character = GetComponent<CharacterManager>();
         }
         
-        // RPC(Remote Procedure Call) : ¿ø°İ ÇÁ·Î½ÃÀú È£Ãâ
-        // ¿ø°İÁ¦¾î¸¦ À§ÇÑ ÄÚµù¾øÀÌ ´Ù¸¥ ÁÖ¼Ò °ø°£¿¡¼­ ÇÔ¼ö³ª ÇÁ·Î½ÃÀú¸¦ ½ÇÇàÇÒ ¼ö ÀÖ°Ô ÇÏ´Â ÇÁ·Î¼¼½º °£ Åë½Å ±â¼ú
+        // RPC(Remote Procedure Call) : ì›ê²© í”„ë¡œì‹œì € í˜¸ì¶œ
+        // ì›ê²©ì œì–´ë¥¼ ìœ„í•œ ì½”ë”©ì—†ì´ ë‹¤ë¥¸ ì£¼ì†Œ ê³µê°„ì—ì„œ í•¨ìˆ˜ë‚˜ í”„ë¡œì‹œì €ë¥¼ ì‹¤í–‰í•  ìˆ˜ ìˆê²Œ í•˜ëŠ” í”„ë¡œì„¸ìŠ¤ ê°„ í†µì‹  ê¸°ìˆ 
 
-        // ¼­¹öRPC : ¾î¶² Å¬¶óÀÌ¾ğÆ®ÀÎÁö »ó°ü¾øÀÌ Å¬¶óÀÌ¾ğÆ®·Î ºÎÅÍ ¼­¹ö·Î Àü´ŞµÇ´Â ¸Ş½ÃÁö
+        // ì„œë²„RPC : ì–´ë–¤ í´ë¼ì´ì–¸íŠ¸ì¸ì§€ ìƒê´€ì—†ì´ í´ë¼ì´ì–¸íŠ¸ë¡œ ë¶€í„° ì„œë²„ë¡œ ì „ë‹¬ë˜ëŠ” ë©”ì‹œì§€
         [ServerRpc]
         public void NotifyServerOfAnimationServerRpc(ulong clientID, string animationID, bool isInteracting) {
-            // ¼­¹ö¸¸ÀÌ Å¬¶óÀÌ¾ğÆ®RPC ¼öÇà °¡´É
-            if (IsServer) { // ÇöÀç ³»°¡ ¼­¹ö¶ó¸é(È£½ºÆ®¶ó¸é?)
-                // Å¬¶óÀÌ¾ğÆ®°¡ ¿¬°áµÈ ´Ù¸¥ ¸ğµç Å¬¶óÀÌ¾ğÆ®µé¿¡¼­ ¾Ö´Ï¸ŞÀÌ¼ÇÀ» ¼öÇàÇÏµµ·Ï ÇÑ´Ù.
+            // ì„œë²„ë§Œì´ í´ë¼ì´ì–¸íŠ¸RPC ìˆ˜í–‰ ê°€ëŠ¥
+            if (IsServer) { // í˜„ì¬ ë‚´ê°€ ì„œë²„ë¼ë©´(í˜¸ìŠ¤íŠ¸ë¼ë©´?)
+                // í´ë¼ì´ì–¸íŠ¸ê°€ ì—°ê²°ëœ ë‹¤ë¥¸ ëª¨ë“  í´ë¼ì´ì–¸íŠ¸ë“¤ì—ì„œ ì• ë‹ˆë©”ì´ì…˜ì„ ìˆ˜í–‰í•˜ë„ë¡ í•œë‹¤.
                 ProcessAllClientsAnimationClientRpc(clientID, animationID, isInteracting);
             }
         }
 
-        // Å¬¶óÀÌ¾ğÆ®RPC : ¼­¹ö·ÎºÎÅÍ ÇÏ³ªÀÇ Å¬¶óÀÌ¾ğÆ® È¤Àº ¸ğµç Å¬¶óÀÌ¾ğÆ® µé¿¡°Ô Àü´ŞµÇ´Â ¸Ş½ÃÁö
+        // í´ë¼ì´ì–¸íŠ¸RPC : ì„œë²„ë¡œë¶€í„° í•˜ë‚˜ì˜ í´ë¼ì´ì–¸íŠ¸ í˜¹ì€ ëª¨ë“  í´ë¼ì´ì–¸íŠ¸ ë“¤ì—ê²Œ ì „ë‹¬ë˜ëŠ” ë©”ì‹œì§€
         [ClientRpc]
-        // ¸¸¾à ³» ¿ÀºêÁ§Æ®°¡ ¾Ö´Ï¸ŞÀÌ¼ÇÀ» Àç»ıÁßÀÌ¶ó¸é ¿¬°áµÈ ´Ù¸¥ ¸ğµç Å¬¶óÀÌ¾ğÆ®µé¿¡°Ô ÀÌ ¿ÀºêÁ§Æ®°¡ ¾Ö´Ï¸ŞÀÌ¼ÇÀ» Àç»ıÇÏ°í ÀÖ´Ù´Â »ç½ÇÀ» ¾Ë·ÁÁÜ
+        // ë§Œì•½ ë‚´ ì˜¤ë¸Œì íŠ¸ê°€ ì• ë‹ˆë©”ì´ì…˜ì„ ì¬ìƒì¤‘ì´ë¼ë©´ ì—°ê²°ëœ ë‹¤ë¥¸ ëª¨ë“  í´ë¼ì´ì–¸íŠ¸ë“¤ì—ê²Œ ì´ ì˜¤ë¸Œì íŠ¸ê°€ ì• ë‹ˆë©”ì´ì…˜ì„ ì¬ìƒí•˜ê³  ìˆë‹¤ëŠ” ì‚¬ì‹¤ì„ ì•Œë ¤ì¤Œ
         private void ProcessAllClientsAnimationClientRpc(ulong clientID, string animationID, bool isInteracting) {
-            // ³» ´Ü¸»¿¡¼­ ³»°¡ ¾Ö´Ï¸ŞÀÌ¼ÇÀ» ¼öÇàÇßÀ» ¶§, ´Ù¸¥ Å¬¶óÀÌ¾ğÆ®ÀÇ ³» ¿ÀºêÁ§Æ®°¡ ¾Ö´Ï¸ŞÀÌ¼ÇÀ» ¼öÇà ÇÑ ÈÄ
-            // Å¬¶óÀÌ¾ğÆ®RPC¿¡ ÀÇÇØ ³» ´Ü¸»¿¡¼­ ¶Ç´Ù½Ã ¾Ö´Ï¸ŞÀÌ¼ÇÀ» ¼öÇàÇÏÁö ¾Êµµ·Ï Å¬¶óÀÌ¾ğÆ® id°¡ ´Ù¸¥ °æ¿ì¿¡¸¸
+            // ë‚´ ë‹¨ë§ì—ì„œ ë‚´ê°€ ì• ë‹ˆë©”ì´ì…˜ì„ ìˆ˜í–‰í–ˆì„ ë•Œ, ë‹¤ë¥¸ í´ë¼ì´ì–¸íŠ¸ì˜ ë‚´ ì˜¤ë¸Œì íŠ¸ê°€ ì• ë‹ˆë©”ì´ì…˜ì„ ìˆ˜í–‰ í•œ í›„
+            // í´ë¼ì´ì–¸íŠ¸RPCì— ì˜í•´ ë‚´ ë‹¨ë§ì—ì„œ ë˜ë‹¤ì‹œ ì• ë‹ˆë©”ì´ì…˜ì„ ìˆ˜í–‰í•˜ì§€ ì•Šë„ë¡ í´ë¼ì´ì–¸íŠ¸ idê°€ ë‹¤ë¥¸ ê²½ìš°ì—ë§Œ
             if (clientID != NetworkManager.Singleton.LocalClientId) {
-                // ¾Ö´Ï¸ŞÀÌ¼Ç ¼öÇà
+                // ì• ë‹ˆë©”ì´ì…˜ ìˆ˜í–‰
                 PerformAnimationFromServer(animationID, isInteracting);
             }
         }
@@ -65,6 +69,27 @@ namespace SoulsLike {
             //anim.applyRootMotion = isInteracting;
             character.animator.SetBool("isInteracting", isInteracting);
             character.animator.CrossFade(animationID, 0.2f);
+        }
+
+        // ë¬´ê¸° ë³€ê²½
+        public void OnRightWeaponChange(int oldWeaponID, int newWeaponID) {
+            if (character.IsOwner) return;
+            WeaponItem newWeapon = WorldItemDatabase.instance.GetWeaponItemByID(newWeaponID);
+
+            if (newWeapon != null) {
+                character.characterInventoryManager.rightWeapon = newWeapon;
+                character.characterWeaponSlotManager.LoadWeaponOnSlot(newWeapon, false);
+            }
+        }
+
+        public void OnLeftWeaponChange(int oldWeaponID, int newWeaponID) {
+            if (character.IsOwner) return;
+            WeaponItem newWeapon = WorldItemDatabase.instance.GetWeaponItemByID(newWeaponID);
+
+            if (newWeapon != null) {
+                character.characterInventoryManager.leftWeapon = newWeapon;
+                character.characterWeaponSlotManager.LoadWeaponOnSlot(newWeapon, true);
+            }
         }
     }
 }

--- a/Assets/Scripts/Common/CharacterManager.cs
+++ b/Assets/Scripts/Common/CharacterManager.cs
@@ -9,7 +9,7 @@ namespace SoulsLike {
         public CharacterAnimatorManager characterAnimatorManager;
         public CharacterWeaponSlotManager characterWeaponSlotManager;
         //public CharacterStatsManager characterStatsManager;
-        //public CharacterInventoryManager characterInventoryManager;
+        public CharacterInventoryManager characterInventoryManager;
         //public CharacterEffectsManager characterEffectsManager;
         public CharacterNetworkManager characterNetworkManager;
 
@@ -55,6 +55,7 @@ namespace SoulsLike {
             characterAnimatorManager = GetComponent<CharacterAnimatorManager>();
             characterWeaponSlotManager = GetComponent<CharacterWeaponSlotManager>();
             characterNetworkManager = GetComponent<CharacterNetworkManager>();
+            characterInventoryManager = GetComponent<CharacterInventoryManager>();
         }
 
         protected virtual void Update() {

--- a/Assets/Scripts/Common/CharacterStatsManager.cs
+++ b/Assets/Scripts/Common/CharacterStatsManager.cs
@@ -11,14 +11,13 @@ namespace SoulsLike {
         
         public int soulsAwardedOnDeath;
 
+        [Header("Stats")]
         public int healthLevel = 10;
         public float maxHealth;
         public float currentHealth;
-
         public int staminaLevel = 10;
         public float maxStamina;
         public float currentStamina;
-
         public int focusLevel = 10;
         public float maxFocus;
         public float currentFocus;
@@ -26,6 +25,11 @@ namespace SoulsLike {
         public int soulCount = 0;
 
         public bool isBoss;
+
+        // 중량 시스템을 만들면 사용할 것
+        //[Header("Equip Load")]
+        //public float currentEquipLoad = 0;
+        //public float maxEquipLoad = 0;
 
         protected virtual void Awake() {
             characterAnimatorManager = GetComponent<CharacterAnimatorManager>();
@@ -39,7 +43,6 @@ namespace SoulsLike {
         public float totalPoiseResetTime; // 강인도 초기화 시간
         public float poiseResetTimer = 0; // 강인도 초기화 타이머
         public bool isStuned; // 그로기 상태
-        
 
         [Header("Armor Absorptions")]
         public float physicalDamageAbsorptionHead;

--- a/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
+++ b/Assets/Scripts/Common/CharacterWeaponSlotManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace SoulsLike {
     public class CharacterWeaponSlotManager : MonoBehaviour {
-        protected CharacterManager characterManager;
+        protected CharacterManager character;
         protected CharacterStatsManager characterStatsManager;
         public CharacterEffectsManager characterEffectsManager;
         protected CharacterAnimatorManager characterAnimatorManager;
@@ -30,7 +30,7 @@ namespace SoulsLike {
         public HandIKTarget leftHandIKTarget;
 
         protected virtual void Awake() {
-            characterManager = GetComponent<CharacterManager>();
+            character = GetComponent<CharacterManager>();
             characterStatsManager = GetComponent<CharacterStatsManager>();
             characterEffectsManager = GetComponent<CharacterEffectsManager>();
             characterAnimatorManager = GetComponent<CharacterAnimatorManager>();
@@ -38,24 +38,24 @@ namespace SoulsLike {
             LoadWeaponHolderSlots();
         }
 
-        // ¼Õ¿¡ ¹«±â°¡ ¾Æ´Ñ ¹«¾ğ°¡¸¦ µé°í ÇÏ´Â µ¿ÀÛÀÌ ³¡³­ÈÄ ¹«±â¸¦ ´Ù½Ã ·ÎµåÇÏ±â À§ÇÑ ÇÔ¼ö
+        // ì†ì— ë¬´ê¸°ê°€ ì•„ë‹Œ ë¬´ì–¸ê°€ë¥¼ ë“¤ê³  í•˜ëŠ” ë™ì‘ì´ ëë‚œí›„ ë¬´ê¸°ë¥¼ ë‹¤ì‹œ ë¡œë“œí•˜ê¸° ìœ„í•œ í•¨ìˆ˜
         public virtual void LoadBothWeaponsOnSlots() {
             LoadWeaponOnSlot(characterInventoryManager.rightWeapon, false);
             LoadWeaponOnSlot(characterInventoryManager.leftWeapon, true);
         }
 
-        // ´ë»ó¿¡°Ô ÇÇÇØ¸¦ ÁÖ±â À§ÇØ ¹«±âÀÇ DamageCollider¸¦ È°¼ºÈ­
+        // ëŒ€ìƒì—ê²Œ í”¼í•´ë¥¼ ì£¼ê¸° ìœ„í•´ ë¬´ê¸°ì˜ DamageColliderë¥¼ í™œì„±í™”
         public virtual void OpenDamageCollider() {
-            if (characterManager.isUsingRightHand) {
+            if (character.isUsingRightHand) {
                 characterEffectsManager.PlayWeaponFX(false);
                 rightHandDamageCollider.EnableDamageCollider();
-            } else if (characterManager.isUsingLeftHand) {
+            } else if (character.isUsingLeftHand) {
                 characterEffectsManager.PlayWeaponFX(true);
                 leftHandDamageCollider.EnableDamageCollider();
             }
         }
 
-        // °ø°İ ¸ğ¼ÇÁß(È¤Àº ³¡³ª°í) ¹«±âÀÇ DamageCollider ºñÈ°¼ºÈ­
+        // ê³µê²© ëª¨ì…˜ì¤‘(í˜¹ì€ ëë‚˜ê³ ) ë¬´ê¸°ì˜ DamageCollider ë¹„í™œì„±í™”
         public virtual void CloseDamageCollider() {
             if (rightHandDamageCollider != null) {
                 characterEffectsManager.StopWeaponFX(false);
@@ -67,9 +67,9 @@ namespace SoulsLike {
             }
         }
 
-        // °¢ ¼Õ¿¡ Componenet·Î Ãß°¡µÇ¾îÀÖ´Â WeaponHolderSlot ½ºÅ©¸³Æ®¸¦ ÂüÁ¶
-        // ¸¸¾à ¿Ş¼ÕÀÇ ½ºÅ©¸³Æ®¶ó¸é ¿Ş¼Õ¿¡ , ¿À¸¥¼ÕÀÇ ½ºÅ©¸³Æ®¶ó¸é ¿À¸¥¼Õ¿¡ ÇÒ´ç
-        // ÇÒ´çµÈ °¢ ¼ÕÀÇ WeaponHolderSlot ½ºÅ©¸³Æ®´Â ÇöÀç ¹«±â¸¦ ·ÎµåÇÏ±â À§ÇØ »ç¿ëµÉ °Í
+        // ê° ì†ì— Componenetë¡œ ì¶”ê°€ë˜ì–´ìˆëŠ” WeaponHolderSlot ìŠ¤í¬ë¦½íŠ¸ë¥¼ ì°¸ì¡°
+        // ë§Œì•½ ì™¼ì†ì˜ ìŠ¤í¬ë¦½íŠ¸ë¼ë©´ ì™¼ì†ì— , ì˜¤ë¥¸ì†ì˜ ìŠ¤í¬ë¦½íŠ¸ë¼ë©´ ì˜¤ë¥¸ì†ì— í• ë‹¹
+        // í• ë‹¹ëœ ê° ì†ì˜ WeaponHolderSlot ìŠ¤í¬ë¦½íŠ¸ëŠ” í˜„ì¬ ë¬´ê¸°ë¥¼ ë¡œë“œí•˜ê¸° ìœ„í•´ ì‚¬ìš©ë  ê²ƒ
         protected virtual void LoadWeaponHolderSlots() {
             WeaponHolderSlot[] weaponHolderSlots = GetComponentsInChildren<WeaponHolderSlot>();
             foreach (WeaponHolderSlot weaponSlot in weaponHolderSlots) {
@@ -89,45 +89,53 @@ namespace SoulsLike {
         public virtual void LoadConsumableOnSlot(ConsumableItem consumableItem) {
         }
 
-        // ÇöÀç °¢ ¼ÕÀÇ WeaponHolderSlot ½ºÅ©¸³Æ®¸¦ ÂüÁ¶ÇÏ¿© ÇöÀç µé·ÁÀÖ´Â ¹«±â¸¦ ·Îµå
+        // í˜„ì¬ ê° ì†ì˜ WeaponHolderSlot ìŠ¤í¬ë¦½íŠ¸ë¥¼ ì°¸ì¡°í•˜ì—¬ í˜„ì¬ ë“¤ë ¤ìˆëŠ” ë¬´ê¸°ë¥¼ ë¡œë“œ
         public virtual void LoadWeaponOnSlot(WeaponItem weaponItem, bool isLeft) {
             if (weaponItem != null) {
                 if (isLeft) {
-                    leftHandSlot.currentWeapon = weaponItem; // ¾çÀâ»óÅÂ¿¡¼­ µ¹¾Æ¿Ã¶§¸¦ À§ÇØ ÇöÀç ¿ŞÂÊ ¹«±â¸¦ ±â¾ïÇÑ´Ù.
+                    leftHandSlot.currentWeapon = weaponItem; // ì–‘ì¡ìƒíƒœì—ì„œ ëŒì•„ì˜¬ë•Œë¥¼ ìœ„í•´ í˜„ì¬ ì™¼ìª½ ë¬´ê¸°ë¥¼ ê¸°ì–µí•œë‹¤.
                     leftHandSlot.LoadWeaponModel(weaponItem);
                     LoadLeftWeaponDamageCollider();
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentLeftWeaponID.Value = weaponItem.itemID;
                 } else {
-                    if (characterManager.isTwoHandingWeapon) {
-                        // ¾çÀâ½Ã ¿ŞÂÊ¼ÕÀÇ ¹«±â¸¦ µîÀ¸·Î ¿Å±â°í, ¿Ş¼Õ¿¡ ÀÖ´Â ¹«±â´Â Á¦°ÅÇÑ´Ù.
+                    if (character.isTwoHandingWeapon) {
+                        // ì–‘ì¡ì‹œ ì™¼ìª½ì†ì˜ ë¬´ê¸°ë¥¼ ë“±ìœ¼ë¡œ ì˜®ê¸°ê³ , ì™¼ì†ì— ìˆëŠ” ë¬´ê¸°ëŠ” ì œê±°í•œë‹¤.
                         backSlot.LoadWeaponModel(leftHandSlot.currentWeapon);
                         leftHandSlot.UnloadWeaponAndDestroy();
-                        characterManager.animator.CrossFade(weaponItem.th_idle, 0.2f);
+                        character.animator.CrossFade(weaponItem.th_idle, 0.2f);
                     } else {
-                        characterManager.animator.CrossFade("BothArmsEmpty", 0.2f);
+                        character.animator.CrossFade("BothArmsEmpty", 0.2f);
                         backSlot.UnloadWeaponAndDestroy();
-                        characterManager.animator.CrossFade(weaponItem.Right_Hand_Idle, 0.2f);
+                        character.animator.CrossFade(weaponItem.Right_Hand_Idle, 0.2f);
                     }
 
-                    // ¾çÀâÀ» ÇÏ´ø ¾ÈÇÏ´ø ¿À¸¥ÂÊÀº º¯ÇÔ¾øÀ½
-                    rightHandSlot.currentWeapon = weaponItem; // ¾çÀâ»óÅÂ¿¡¼­ µ¹¾Æ¿Ã¶§¸¦ À§ÇØ ÇöÀç ¿À¸¥ÂÊ ¹«±â¸¦ ±â¾ïÇÑ´Ù.
+                    // ì–‘ì¡ì„ í•˜ë˜ ì•ˆí•˜ë˜ ì˜¤ë¥¸ìª½ì€ ë³€í•¨ì—†ìŒ
+                    rightHandSlot.currentWeapon = weaponItem; // ì–‘ì¡ìƒíƒœì—ì„œ ëŒì•„ì˜¬ë•Œë¥¼ ìœ„í•´ í˜„ì¬ ì˜¤ë¥¸ìª½ ë¬´ê¸°ë¥¼ ê¸°ì–µí•œë‹¤.
                     rightHandSlot.LoadWeaponModel(weaponItem);
                     LoadRightWeaponDamageCollider();
-                    LoadTwoHandIKTargets(characterManager.isTwoHandingWeapon);
+                    LoadTwoHandIKTargets(character.isTwoHandingWeapon);
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentRightWeaponID.Value = weaponItem.itemID;
                 }
             } else {
                 weaponItem = unarmedWeapon;
                 if (isLeft) {
-                    characterManager.animator.CrossFade("LeftArmEmpty", 0.2f);
+                    character.animator.CrossFade("LeftArmEmpty", 0.2f);
                     characterInventoryManager.leftWeapon = unarmedWeapon;
                     leftHandSlot.currentWeapon = weaponItem;
                     leftHandSlot.LoadWeaponModel(weaponItem);
                     LoadLeftWeaponDamageCollider();
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentLeftWeaponID.Value = WorldItemDatabase.instance.unarmedWeapon.itemID;
                 } else {
-                    characterManager.animator.CrossFade("RightArmEmpty", 0.2f);
+                    character.animator.CrossFade("RightArmEmpty", 0.2f);
                     characterInventoryManager.rightWeapon = unarmedWeapon;
                     rightHandSlot.currentWeapon = weaponItem;
                     rightHandSlot.LoadWeaponModel(weaponItem);
                     LoadRightWeaponDamageCollider();
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentRightWeaponID.Value = WorldItemDatabase.instance.unarmedWeapon.itemID;
                 }
             }
         }
@@ -138,10 +146,10 @@ namespace SoulsLike {
             leftHandDamageCollider.fireDamage = characterInventoryManager.leftWeapon.fireDamage;
             leftHandDamageCollider.teamIDNumber = characterStatsManager.teamIDNumber;
 
-            leftHandDamageCollider.characterManager = characterManager;
-            // ¿ŞÂÊ ¹«±âÀÇ DamageCollider¿¡ ÇöÀç ¿ŞÂÊ ¹«±âÀÇ °­ÀÎµµ °¨¼âÀ²À» Àü´Ş
+            leftHandDamageCollider.characterManager = character;
+            // ì™¼ìª½ ë¬´ê¸°ì˜ DamageColliderì— í˜„ì¬ ì™¼ìª½ ë¬´ê¸°ì˜ ê°•ì¸ë„ ê°ì‡„ìœ¨ì„ ì „ë‹¬
             leftHandDamageCollider.poiseBreak = characterInventoryManager.leftWeapon.poiseBreak;
-            // ÇöÀç ¿ŞÂÊ¼Õ¿¡ µé·ÁÀÖ´Â ¹«±â ¸ğµ¨ÀÇ ÀÚ½Ä¿¡ ÀÖ´Â WeaponFX ½ºÅ©¸³Æ® ÆÄÀÏÀ» ºÒ·¯¿È
+            // í˜„ì¬ ì™¼ìª½ì†ì— ë“¤ë ¤ìˆëŠ” ë¬´ê¸° ëª¨ë¸ì˜ ìì‹ì— ìˆëŠ” WeaponFX ìŠ¤í¬ë¦½íŠ¸ íŒŒì¼ì„ ë¶ˆëŸ¬ì˜´
             characterEffectsManager.leftWeaponFX = leftHandSlot.currentWeaponModel.GetComponentInChildren<WeaponFX>();
         }
 
@@ -151,24 +159,24 @@ namespace SoulsLike {
             rightHandDamageCollider.fireDamage = characterInventoryManager.rightWeapon.fireDamage;
             rightHandDamageCollider.teamIDNumber = characterStatsManager.teamIDNumber;
 
-            rightHandDamageCollider.characterManager = characterManager;
-            // ¿À¸¥ÂÊ ¹«±âÀÇ DamageCollider¿¡ ÇöÀç ¿À¸¥ÂÊ ¹«±âÀÇ °­ÀÎµµ °¨¼âÀ²À» Àü´Ş
+            rightHandDamageCollider.characterManager = character;
+            // ì˜¤ë¥¸ìª½ ë¬´ê¸°ì˜ DamageColliderì— í˜„ì¬ ì˜¤ë¥¸ìª½ ë¬´ê¸°ì˜ ê°•ì¸ë„ ê°ì‡„ìœ¨ì„ ì „ë‹¬
             rightHandDamageCollider.poiseBreak = characterInventoryManager.rightWeapon.poiseBreak;
-            // ÇöÀç ¿À¸¥ÂÊ¼Õ¿¡ µé·ÁÀÖ´Â ¹«±â ¸ğµ¨ÀÇ ÀÚ½Ä¿¡ ÀÖ´Â WeaponFX ½ºÅ©¸³Æ® ÆÄÀÏÀ» ºÒ·¯¿È
+            // í˜„ì¬ ì˜¤ë¥¸ìª½ì†ì— ë“¤ë ¤ìˆëŠ” ë¬´ê¸° ëª¨ë¸ì˜ ìì‹ì— ìˆëŠ” WeaponFX ìŠ¤í¬ë¦½íŠ¸ íŒŒì¼ì„ ë¶ˆëŸ¬ì˜´
             characterEffectsManager.rightWeaponFX = rightHandSlot.currentWeaponModel.GetComponentInChildren<WeaponFX>();
         }
 
-        public virtual void GrantWeaponAttackingPoiseBonus() { // (Æ¯)´ëÇü¹«±â °ø°İ µµÁß °­ÀÎµµ º¸³Ê½º ÇÕ»ê
-            // ÀûÀÇ °æ¿ì ¹«±â¸¦ ±³Ã¼ÇÏ´Â »óÈ²ÀÌ ÈçÇÏÁö ¾ÊÀ¸¹Ç·Î °ø°İ½Ã °­ÀÎµµ º¸³Ê½º¸¦ ½ºÅÈÀ¸·Î °¡Áü
+        public virtual void GrantWeaponAttackingPoiseBonus() { // (íŠ¹)ëŒ€í˜•ë¬´ê¸° ê³µê²© ë„ì¤‘ ê°•ì¸ë„ ë³´ë„ˆìŠ¤ í•©ì‚°
+            // ì ì˜ ê²½ìš° ë¬´ê¸°ë¥¼ êµì²´í•˜ëŠ” ìƒí™©ì´ í”í•˜ì§€ ì•Šìœ¼ë¯€ë¡œ ê³µê²©ì‹œ ê°•ì¸ë„ ë³´ë„ˆìŠ¤ë¥¼ ìŠ¤íƒ¯ìœ¼ë¡œ ê°€ì§
             characterStatsManager.totalPoiseDefense += attackingWeapon.offensivePoiseBonus;
         }
 
-        public virtual void ResetWeaponAttackingPoiseBonus() { // °ø°İÀÌ ³¡³ª¸é °­ÀÎµµ º¸³Ê½º ÃÊ±âÈ­
+        public virtual void ResetWeaponAttackingPoiseBonus() { // ê³µê²©ì´ ëë‚˜ë©´ ê°•ì¸ë„ ë³´ë„ˆìŠ¤ ì´ˆê¸°í™”
             characterStatsManager.totalPoiseDefense = characterStatsManager.armorPoiseBonus;
         }
 
         public virtual void LoadTwoHandIKTargets(bool isTwoHandingWeapon) {
-            // ¿À¸¥ÂÊ ½½·Ô¿¡ ÀÖ´Â ¹«±â¸¦ ¾ç¼ÕÀâ±â ÇÒ °ÍÀÌ¹Ç·Î ¿À¸¥¼Õ ½½·Ô¸¸ ÂüÁ¶
+            // ì˜¤ë¥¸ìª½ ìŠ¬ë¡¯ì— ìˆëŠ” ë¬´ê¸°ë¥¼ ì–‘ì†ì¡ê¸° í•  ê²ƒì´ë¯€ë¡œ ì˜¤ë¥¸ì† ìŠ¬ë¡¯ë§Œ ì°¸ì¡°
             HandIKTarget[] handIKTargets = rightHandSlot.currentWeaponModel.GetComponentsInChildren<HandIKTarget>();
             foreach (HandIKTarget handIKTarget in handIKTargets) {
                 if (handIKTarget.isLeft) leftHandIKTarget = handIKTarget;

--- a/Assets/Scripts/GameSessionManager.cs
+++ b/Assets/Scripts/GameSessionManager.cs
@@ -7,11 +7,13 @@ namespace SoulsLike {
 
         public static GameSessionManager instance;
 
-        // ��Ʈ��ũ �����
+        // 네트워크 실험용
         [Header("Debug Join Game")]
         [SerializeField] bool startGameAsClient;
         [SerializeField] bool shutdownNetwork;
 
+        [Header("Player In Game")]
+        public List<PlayerManager> players = new List<PlayerManager>();
         private void Awake() {
             if (instance == null) instance = this;
             else Destroy(gameObject);
@@ -25,6 +27,18 @@ namespace SoulsLike {
             if (shutdownNetwork) {
                 shutdownNetwork = false;
                 NetworkManager.Singleton.Shutdown();
+            }
+        }
+
+        // 게임에 참가중인 모든 플레이어를 리스트에 등록
+        public void AddPlayerToActivePlayerList(PlayerManager player) {
+            if (!players.Contains(player)) players.Add(player);
+
+            // 플레이어 리스트의 항목중 비어있는 항목은 삭제
+            for (int i = players.Count - 1; i > -1; i--) {
+                if (players[i] == null) {
+                    players.RemoveAt(i);
+                }
             }
         }
     }

--- a/Assets/Scripts/MainMenuManager.cs
+++ b/Assets/Scripts/MainMenuManager.cs
@@ -16,7 +16,6 @@ namespace SoulsLike {
             PlayerManager player = FindObjectOfType<PlayerManager>();
             if (player != null) {
                 UIManager.instance.transform.gameObject.GetComponent<CanvasGroup>().alpha = 1;
-                player.transform.position = new Vector3(-3.5f, 5f, -19f);
             }
         }
     }

--- a/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerWeaponSlotManager.cs
@@ -36,14 +36,16 @@ namespace SoulsLike {
         public override void LoadWeaponOnSlot(WeaponItem weaponItem, bool isLeft) {
             if (weaponItem != null) {
                 if (isLeft) {
-                    leftHandSlot.currentWeapon = weaponItem; // ¾çÀâ»óÅÂ¿¡¼­ µ¹¾Æ¿Ã¶§¸¦ À§ÇØ ÇöÀç ¿ŞÂÊ ¹«±â¸¦ ±â¾ïÇÑ´Ù.
+                    leftHandSlot.currentWeapon = weaponItem; // ì–‘ì¡ìƒíƒœì—ì„œ ëŒì•„ì˜¬ë•Œë¥¼ ìœ„í•´ í˜„ì¬ ì™¼ìª½ ë¬´ê¸°ë¥¼ ê¸°ì–µí•œë‹¤.
                     leftHandSlot.LoadWeaponModel(weaponItem);
                     LoadLeftWeaponDamageCollider();
                     quickSlots.UpdateWeaponQuickSlotsUI(true, weaponItem);
                     animator.CrossFade(weaponItem.Left_Hand_Idle, 0.2f);
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentLeftWeaponID.Value = weaponItem.itemID;
                 } else {
                     if (inputHandler.twoHandFlag) {
-                        // ¾çÀâ½Ã ¿ŞÂÊ¼ÕÀÇ ¹«±â¸¦ µîÀ¸·Î ¿Å±â°í, ¿Ş¼Õ¿¡ ÀÖ´Â ¹«±â´Â Á¦°ÅÇÑ´Ù.
+                        // ì–‘ì¡ì‹œ ì™¼ìª½ì†ì˜ ë¬´ê¸°ë¥¼ ë“±ìœ¼ë¡œ ì˜®ê¸°ê³ , ì™¼ì†ì— ìˆëŠ” ë¬´ê¸°ëŠ” ì œê±°í•œë‹¤.
                         backSlot.LoadWeaponModel(leftHandSlot.currentWeapon);
                         leftHandSlot.UnloadWeaponAndDestroy();
                         animator.CrossFade(weaponItem.th_idle, 0.2f);
@@ -53,11 +55,13 @@ namespace SoulsLike {
                         animator.CrossFade(weaponItem.Right_Hand_Idle, 0.2f);
                     }
 
-                    // ¾çÀâÀ» ÇÏ´ø ¾ÈÇÏ´ø ¿À¸¥ÂÊÀº º¯ÇÔ¾øÀ½
-                    rightHandSlot.currentWeapon = weaponItem; // ¾çÀâ»óÅÂ¿¡¼­ µ¹¾Æ¿Ã¶§¸¦ À§ÇØ ÇöÀç ¿À¸¥ÂÊ ¹«±â¸¦ ±â¾ïÇÑ´Ù.
+                    // ì–‘ì¡ì„ í•˜ë˜ ì•ˆí•˜ë˜ ì˜¤ë¥¸ìª½ì€ ë³€í•¨ì—†ìŒ
+                    rightHandSlot.currentWeapon = weaponItem; // ì–‘ì¡ìƒíƒœì—ì„œ ëŒì•„ì˜¬ë•Œë¥¼ ìœ„í•´ í˜„ì¬ ì˜¤ë¥¸ìª½ ë¬´ê¸°ë¥¼ ê¸°ì–µí•œë‹¤.
                     rightHandSlot.LoadWeaponModel(weaponItem);
                     LoadRightWeaponDamageCollider();
                     quickSlots.UpdateWeaponQuickSlotsUI(false, weaponItem);
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentRightWeaponID.Value = weaponItem.itemID;
                 }
             } else {
                 weaponItem = unarmedWeapon;
@@ -68,6 +72,8 @@ namespace SoulsLike {
                     leftHandSlot.LoadWeaponModel(weaponItem);
                     LoadLeftWeaponDamageCollider();
                     quickSlots.UpdateWeaponQuickSlotsUI(true, weaponItem);
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentLeftWeaponID.Value = WorldItemDatabase.instance.unarmedWeapon.itemID;
                 } else {
                     animator.CrossFade("RightArmEmpty", 0.2f);
                     playerInventoryManager.rightWeapon = unarmedWeapon;
@@ -75,6 +81,8 @@ namespace SoulsLike {
                     rightHandSlot.LoadWeaponModel(weaponItem);
                     LoadRightWeaponDamageCollider();
                     quickSlots.UpdateWeaponQuickSlotsUI(false, weaponItem);
+                    if (character.IsOwner)
+                        character.characterNetworkManager.currentRightWeaponID.Value = WorldItemDatabase.instance.unarmedWeapon.itemID;
                 }
             }
         }
@@ -82,18 +90,18 @@ namespace SoulsLike {
         public void SuccessfullyThrowFireBomb() {
             Destroy(playerEffectsManager.instantiatedFXModel);
             BombConsumableItem fireBombItem = playerInventoryManager.currentConsumable as BombConsumableItem;
-            // Instantiate¸Ş¼­µå¿¡ ¿¡ Ä«¸Ş¶óÀÇ È¸Àü°ªÀ» ³Ñ°ÜÁÖ´Â ÀÌÀ¯´Â ¾î¶² °æ¿ì¿¡¶óµµ ÇÃ·¹ÀÌ¾îÀÇ Á¤¸é ¹æÇâ¿¡¼­ È­¿°º´ÀÌ ½ºÆùµÇ¾î¾ß ÇÏ±â ¶§¹®
+            // Instantiateë©”ì„œë“œì— ì— ì¹´ë©”ë¼ì˜ íšŒì „ê°’ì„ ë„˜ê²¨ì£¼ëŠ” ì´ìœ ëŠ” ì–´ë–¤ ê²½ìš°ì—ë¼ë„ í”Œë ˆì´ì–´ì˜ ì •ë©´ ë°©í–¥ì—ì„œ í™”ì—¼ë³‘ì´ ìŠ¤í°ë˜ì–´ì•¼ í•˜ê¸° ë•Œë¬¸
             GameObject activeBombModel = Instantiate(fireBombItem.liveBombModel, rightHandSlot.transform.position, cameraHandler.cameraPivotTransform.rotation);
-            // È­¿°º´ÀÇ È¸Àü°ªÀº Ä«¸Ş¶óÀÇ È¸Àü°ª°ú ¸ÂÃç ÇÃ·¹ÀÌ¾î°¡ ¹Ù¶óº¸´Â ¹æÇâÀ¸·Î ³¯¾Æ°¡°Ô ÇÑ´Ù
+            // í™”ì—¼ë³‘ì˜ íšŒì „ê°’ì€ ì¹´ë©”ë¼ì˜ íšŒì „ê°’ê³¼ ë§ì¶° í”Œë ˆì´ì–´ê°€ ë°”ë¼ë³´ëŠ” ë°©í–¥ìœ¼ë¡œ ë‚ ì•„ê°€ê²Œ í•œë‹¤
             activeBombModel.transform.rotation = Quaternion.Euler(cameraHandler.cameraPivotTransform.eulerAngles.x, playerManager.lockOnTransform.eulerAngles.y, 0);
 
-            // È­¿°º´ ¼Óµµ ¼³Á¤
+            // í™”ì—¼ë³‘ ì†ë„ ì„¤ì •
             BombDamageCollider damageCollider = activeBombModel.GetComponentInChildren<BombDamageCollider>();
             damageCollider.contactDamage = fireBombItem.baseDamage;
             damageCollider.fireExplosionDamage = fireBombItem.explosiveDamage;
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.forward * fireBombItem.forwardVelocity);
             damageCollider.bombRigidbody.AddForce(activeBombModel.transform.up * fireBombItem.upwardVelocity);
-            damageCollider.teamIDNumber = playerStatsManager.teamIDNumber; // ÇÇ¾Æ½Äº°À» À§ÇÑ ÆÀID ¼³Á¤
+            damageCollider.teamIDNumber = playerStatsManager.teamIDNumber; // í”¼ì•„ì‹ë³„ì„ ìœ„í•œ íŒ€ID ì„¤ì •
                                                                            // LoadWeaponSlot(playerInventory.rightWeapon, false);
 
         }

--- a/Assets/WorldItemDatabase.cs
+++ b/Assets/WorldItemDatabase.cs
@@ -6,17 +6,31 @@ using System.Linq;
 namespace SoulsLike {
     public class WorldItemDatabase : MonoBehaviour {
         public static WorldItemDatabase instance;
-
+        
+        public WeaponItem unarmedWeapon;
+        public List<Item> allItems = new List<Item>();
         public List<WeaponItem> weaponItems = new List<WeaponItem>();
         public List<EquipmentItem> equipmentItems = new List<EquipmentItem>();
-
         private void Awake() {
             if (instance == null) instance = this;
             else Destroy(gameObject);
+
+            // allItems ë¦¬ìŠ¤íŠ¸ì— ê²Œì„ì— ì¡´ì¬í•˜ëŠ” ëª¨ë“  ì•„ì´í…œë“¤ì„ ë‹´ê³  ì‹ë³„ë²ˆí˜¸ë¥¼ ë¶™ì„
+            foreach (var item in weaponItems) {
+                allItems.Add(item);
+            }
+
+            foreach (var item in equipmentItems) {
+                allItems.Add(item);
+            }
+
+            for (int i = 0; i < allItems.Count; i++) {
+                allItems[i].itemID = i;
+            }
         }
 
         public WeaponItem GetWeaponItemByID(int weaponID) {
-            // ÀüÃ¼ ¸®½ºÆ®¸¦ Å½»öÇÏ¿© id°¡ ÀÏÄ¡ÇÏ´Â °¡Àå Ã¹¹øÂ° WeaponItemÀ» ¹İÈ¯, Ã£Áö ¸øÇÏ¸é null ¹İÈ¯
+            // ì „ì²´ ë¦¬ìŠ¤íŠ¸ë¥¼ íƒìƒ‰í•˜ì—¬ idê°€ ì¼ì¹˜í•˜ëŠ” ê°€ì¥ ì²«ë²ˆì§¸ WeaponItemì„ ë°˜í™˜, ì°¾ì§€ ëª»í•˜ë©´ null ë°˜í™˜
             return weaponItems.FirstOrDefault(weapon => weapon.itemID == weaponID);
         }
 


### PR DESCRIPTION
게임내의 플레이어들의 무기를 동기화

# WorldItemDatabase
- 게임이 시작되면 데이터베이스가 직접 모든 아이템들에 식별번호를 붙여줌

# CharacterNetworkManager
- 캐릭터가 현재 들고있는 왼손 무기와 오른손 무기의 식별번호를 저장할 네트워크 변수
- 왼손, 오른손의 무기를 변경하는 메서드
- 네트워크를 통해 다른 클라이언트의 화면에 내 캐릭터의 무기가 변경되는 것을 출력하기 위한 것이므로 이 오브젝트가 내 것이면 실행하지 않고 반환

# CharacterWeaponSlotManager
- 각 손 슬롯의 현재 들려있는 무기를 로드할 때 이 클라이언트가 오브젝트의 주인이라면 네트워크에 알려줘야함

# PlayerWeaponSlotManager
- LoadWeaponOnSlot 메서드가 기반 클래스의 메서드를 호출하지 않기 때문에 네트워크에 알리는 부분 추가

# GameSessionManager
- 현재 게임에 참가중인 모든 플레이어를 담을 리스트와 메서드

# PlayerManager
- 네트워크에 스폰되면 플레이어의 무기 식별 네트워크 변수의 OnValueChanged 이벤트에 무기를 변경하는 메서드를 연결
- 다른 플레이어 캐릭터의 무기들을 로드하는 메서드
- NetworkManager의 싱글톤 이벤트에 연결할 이벤트 핸들러 작성
- 플레이어 리스트에 자신을 전달하고 만약 자신이 호스트가 아닌 단순 클라이언트라면 플레이어 리스트의 모든 다른 플레이어의 캐릭터의 무기를 로드