### PR TITLE
Netcode

### DIFF
--- a/Assets/Prefabs/Player_CC.prefab
+++ b/Assets/Prefabs/Player_CC.prefab
@@ -8359,6 +8359,7 @@ MonoBehaviour:
   animator: {fileID: 0}
   characterAnimatorManager: {fileID: 0}
   characterWeaponSlotManager: {fileID: 0}
+  characterInventoryManager: {fileID: 0}
   characterNetworkManager: {fileID: 0}
   lockOnTransform: {fileID: 199501606}
   backStabCollider: {fileID: 229186707681697945}
@@ -8376,7 +8377,6 @@ MonoBehaviour:
   isGrabbed: 0
   isRotatingWithRootMotion: 0
   canRotate: 0
-  isInAir: 0
   isGrounded: 0
   isTwoHandingWeapon: 0
   isClimbing: 0
@@ -8441,10 +8441,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5b39c446a406e4c41b9b3b2a233306f3, type: 2}
   - {fileID: 11400000, guid: 32f44fc45c1141b4a8638938b109e01c, type: 2}
   - {fileID: 11400000, guid: ce7fac139c06bfc4390db328c045d28c, type: 2}
-  currentHelmetEquipment: {fileID: 11400000, guid: fc1e36634f4ce4540be04eb96bc679c0, type: 2}
-  currentTorsoEquipment: {fileID: 0}
-  currentLegEquipment: {fileID: 11400000, guid: d4d8bac998410a84594783304bc4a1f9, type: 2}
-  currentGuntletEquipment: {fileID: 11400000, guid: 47a41915e5ae5494591a6021240b8c1d, type: 2}
+  currentHelmetEquipment: {fileID: 11400000, guid: 9fd0aea1c6995794a8ae5a54a1662bcf, type: 2}
+  currentTorsoEquipment: {fileID: 11400000, guid: 45e938a30804f964ab9f69c147c7b9c9, type: 2}
+  currentLegEquipment: {fileID: 11400000, guid: 73115051e8b2f47488a248e47d3fbccd, type: 2}
+  currentGuntletEquipment: {fileID: 11400000, guid: 5bdbecf98282d1148968477099f17041, type: 2}
   currentRightWeaponIndex: 0
   currentLeftWeaponIndex: 0
   currentSpellIndex: 0
@@ -8637,6 +8637,18 @@ MonoBehaviour:
   isSprinting:
     m_InternalValue: 0
   isLockedOn:
+    m_InternalValue: 0
+  currentRightWeaponID:
+    m_InternalValue: 0
+  currentLeftWeaponID:
+    m_InternalValue: 0
+  currentHeadEquipmentID:
+    m_InternalValue: 0
+  currentTorsoEquipmentID:
+    m_InternalValue: 0
+  currentGuntletEquipmentID:
+    m_InternalValue: 0
+  currentLegEquipmentID:
     m_InternalValue: 0
 --- !u!143 &-2231115656020088457
 CharacterController:

--- a/Assets/Scripts/CharacterNetworkManager.cs
+++ b/Assets/Scripts/CharacterNetworkManager.cs
@@ -35,6 +35,10 @@ namespace SoulsLike {
         [Header("Equipment")]
         public NetworkVariable<int> currentRightWeaponID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
         public NetworkVariable<int> currentLeftWeaponID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<int> currentHeadEquipmentID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<int> currentTorsoEquipmentID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<int> currentGuntletEquipmentID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        public NetworkVariable<int> currentLegEquipmentID = new NetworkVariable<int>(0, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
         protected virtual void Awake() {
             character = GetComponent<CharacterManager>();
@@ -81,7 +85,6 @@ namespace SoulsLike {
                 character.characterWeaponSlotManager.LoadWeaponOnSlot(newWeapon, false);
             }
         }
-
         public void OnLeftWeaponChange(int oldWeaponID, int newWeaponID) {
             if (character.IsOwner) return;
             WeaponItem newWeapon = WorldItemDatabase.instance.GetWeaponItemByID(newWeaponID);
@@ -91,5 +94,6 @@ namespace SoulsLike {
                 character.characterWeaponSlotManager.LoadWeaponOnSlot(newWeapon, true);
             }
         }
+
     }
 }

--- a/Assets/Scripts/Items/Equipment/PlayerEquipmentManager.cs
+++ b/Assets/Scripts/Items/Equipment/PlayerEquipmentManager.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 namespace SoulsLike {
     public class PlayerEquipmentManager : MonoBehaviour {
         InputHandler inputHandler;
-        PlayerInventoryManager playerInventoryManager;
+        PlayerManager player;
+        //PlayerInventoryManager playerInventoryManager;
 
         [Header("Equipment Model Changer")]
         HelmetModelChanger helmetModelChanger;
@@ -14,7 +15,7 @@ namespace SoulsLike {
         BootsModelChanger bootsModelChanger;
         GuntletModelChanger guntletModelChanger;
         CapeModelChanger capeModelChanger;
-        PlayerStatsManager playerStatsManager;
+        //PlayerStatsManager playerStatsManager;
 
         [Header("Default Naked Models")]
         //public GameObject nakedHeadModel;
@@ -29,8 +30,7 @@ namespace SoulsLike {
 
         private void Awake() {
             inputHandler = GetComponent<InputHandler>();
-            playerInventoryManager = GetComponent<PlayerInventoryManager>();
-            playerStatsManager = GetComponent<PlayerStatsManager>();
+            player = GetComponent<PlayerManager>();
 
             helmetModelChanger = GetComponentInChildren<HelmetModelChanger>();
             torsoModelChanger = GetComponentInChildren<TorsoModelChanger>();
@@ -44,64 +44,90 @@ namespace SoulsLike {
             EquipAllEquipmentModels();
         }
 
-        // Ω√¿€«“∂ß «√∑π¿ÃæÓø°∞‘ º≥¡§µ» ¿Â∫Ò∏¶ ∏µŒ ¿Â¬¯«—¥Ÿ
+        // ÏãúÏûëÌï†Îïå ÌîåÎ†àÏù¥Ïñ¥ÏóêÍ≤å ÏÑ§Ï†ïÎêú Ïû•ÎπÑÎ•º Î™®Îëê Ïû•Ï∞©ÌïúÎã§
         public void EquipAllEquipmentModels() {
             helmetModelChanger.UnEquipAllHelmetModels();
-            if (playerInventoryManager.currentHelmetEquipment != null) {
+            if (player.playerInventoryManager.currentHelmetEquipment != null) {
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentHeadEquipmentID.Value = player.playerInventoryManager.currentHelmetEquipment.itemID;
+                }
                 //nakedHeadModel.SetActive(false);
-                helmetModelChanger.EquipHelmetModelByName(playerInventoryManager.currentHelmetEquipment.helmetModelName);
-                playerStatsManager.physicalDamageAbsorptionHead = playerInventoryManager.currentHelmetEquipment.physicalDefense;
+                helmetModelChanger.EquipHelmetModelByName(player.playerInventoryManager.currentHelmetEquipment.helmetModelName);
+                player.playerStatsManager.physicalDamageAbsorptionHead = player.playerInventoryManager.currentHelmetEquipment.physicalDefense;
                 //Debug.Log("Head Absorption : " + playerStats.physicalDamageAbsorptionHead + "%");
             } else {
                 //nakedHeadModel.SetActive(true);
                 helmetModelChanger.EquipHelmetModelByName(nakedHeadModel);
-                playerStatsManager.physicalDamageAbsorptionHead = 0;
+                player.playerStatsManager.physicalDamageAbsorptionHead = 0;
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentHeadEquipmentID.Value = -1;
+                }
             }
 
             torsoModelChanger.UnEquipAllTorsoModels();
             capeModelChanger.UnEquipAllCapeModels();
             
-            if (playerInventoryManager.currentTorsoEquipment != null) {
-                torsoModelChanger.EquipTorsoModelByName(playerInventoryManager.currentTorsoEquipment.torsoModelName);
-                capeModelChanger.EquipCapeModelByName(playerInventoryManager.currentTorsoEquipment.capeModelName);
-                playerStatsManager.physicalDamageAbsorptionBody = playerInventoryManager.currentTorsoEquipment.physicalDefense;
+            if (player.playerInventoryManager.currentTorsoEquipment != null) {
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentTorsoEquipmentID.Value = player.playerInventoryManager.currentTorsoEquipment.itemID;
+                }
+                torsoModelChanger.EquipTorsoModelByName(player.playerInventoryManager.currentTorsoEquipment.torsoModelName);
+                capeModelChanger.EquipCapeModelByName(player.playerInventoryManager.currentTorsoEquipment.capeModelName);
+                player.playerStatsManager.physicalDamageAbsorptionBody = player.playerInventoryManager.currentTorsoEquipment.physicalDefense;
                 //Debug.Log("Body Absorption : " + playerStats.physicalDamageAbsorptionBody + "%");
             } else {
                 torsoModelChanger.EquipTorsoModelByName(nakedTorsoModel);
                 capeModelChanger.EquipCapeModelByName(nakedCapeModel);
-                playerStatsManager.physicalDamageAbsorptionBody = 0;
+                player.playerStatsManager.physicalDamageAbsorptionBody = 0;
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentTorsoEquipmentID.Value = -1;
+                }
             }
 
             legModelChanger.UnEquipAllLegModels();
             bootsModelChanger.UnEquipAllBootsModels();
-            if (playerInventoryManager.currentLegEquipment != null) {
-                legModelChanger.EquipLegModelByName(playerInventoryManager.currentLegEquipment.legModelName);
-                bootsModelChanger.EquipBootsModelByName(playerInventoryManager.currentLegEquipment.bootsModelName);
-                playerStatsManager.physicalDamageAbsorptionLegs = playerInventoryManager.currentLegEquipment.physicalDefense;
+            if (player.playerInventoryManager.currentLegEquipment != null) {
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentLegEquipmentID.Value = player.playerInventoryManager.currentLegEquipment.itemID;
+                }
+                legModelChanger.EquipLegModelByName(player.playerInventoryManager.currentLegEquipment.legModelName);
+                bootsModelChanger.EquipBootsModelByName(player.playerInventoryManager.currentLegEquipment.bootsModelName);
+                player.playerStatsManager.physicalDamageAbsorptionLegs = player.playerInventoryManager.currentLegEquipment.physicalDefense;
                 //Debug.Log("Legs Absorption : " + playerStats.physicalDamageAbsorptionLegs + "%");
             } else {
                 legModelChanger.EquipLegModelByName(nakedLegModel);
                 bootsModelChanger.EquipBootsModelByName(nakedBootsModel);
-                playerStatsManager.physicalDamageAbsorptionLegs = 0;
+                player.playerStatsManager.physicalDamageAbsorptionLegs = 0;
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentLegEquipmentID.Value = -1;
+                }
             }
 
             guntletModelChanger.UnEquipAllGuntletModels();
-            if (playerInventoryManager.currentGuntletEquipment != null) {
-                guntletModelChanger.EquipGuntletModelByName(playerInventoryManager.currentGuntletEquipment.guntletModelName);
-                playerStatsManager.physicalDamageAbsorptionHands = playerInventoryManager.currentGuntletEquipment.physicalDefense;
+            if (player.playerInventoryManager.currentGuntletEquipment != null) {
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentGuntletEquipmentID.Value = player.playerInventoryManager.currentGuntletEquipment.itemID;
+                }
+                guntletModelChanger.EquipGuntletModelByName(player.playerInventoryManager.currentGuntletEquipment.guntletModelName);
+                player.playerStatsManager.physicalDamageAbsorptionHands = player.playerInventoryManager.currentGuntletEquipment.physicalDefense;
                 //Debug.Log("Hands Absorption : " + playerStats.physicalDamageAbsorptionHands + "%");
             } else {
                 guntletModelChanger.EquipGuntletModelByName(nakedGuntletModel);
-                playerStatsManager.physicalDamageAbsorptionHands = 0;
+                player.playerStatsManager.physicalDamageAbsorptionHands = 0;
+                if (player.IsOwner) {
+                    player.playerNetworkManager.currentGuntletEquipmentID.Value = -1;
+                }
             }
+
+
         }
 
-        // πÊæÓøÎ Collider ¿˚øÎ
+        // Î∞©Ïñ¥Ïö© Collider Ï†ÅÏö©
         public void OpenBlockingCollider() {
-            if (inputHandler.twoHandFlag) { // æÁ¿‚Ω√ ø¿∏•º’ π´±‚¿« ∞Ê∞®¿≤ ¿˚øÎ
-                blockingCollider.SetColliderDamageAbsorption(playerInventoryManager.rightWeapon);
-            } else { // æ∆¥“∞ÊøÏ øﬁº’ π´±‚¿« ∞Ê∞®¿≤ ¿˚øÎ
-                blockingCollider.SetColliderDamageAbsorption(playerInventoryManager.leftWeapon);
+            if (inputHandler.twoHandFlag) { // ÏñëÏû°Ïãú Ïò§Î•∏ÏÜê Î¨¥Í∏∞Ïùò Í≤ΩÍ∞êÏú® Ï†ÅÏö©
+                blockingCollider.SetColliderDamageAbsorption(player.playerInventoryManager.rightWeapon);
+            } else { // ÏïÑÎãêÍ≤ΩÏö∞ ÏôºÏÜê Î¨¥Í∏∞Ïùò Í≤ΩÍ∞êÏú® Ï†ÅÏö©
+                blockingCollider.SetColliderDamageAbsorption(player.playerInventoryManager.leftWeapon);
             }
             blockingCollider.EnableBlockingCollider();
         }

--- a/Assets/Scripts/PlayerNetworkManager.cs
+++ b/Assets/Scripts/PlayerNetworkManager.cs
@@ -5,6 +5,56 @@ using Unity.Netcode;
 
 namespace SoulsLike {
     public class PlayerNetworkManager : CharacterNetworkManager {
+        PlayerManager player;
 
+        protected override void Awake() {
+            base.Awake();
+            player = GetComponent<PlayerManager>();
+        }
+        // 갑옷 변경
+        public void OnHeadEquipmentChange(int oldEquipmentID, int newEquipmentID) {
+            if (player.IsOwner) return;
+            EquipmentItem equipment = WorldItemDatabase.instance.GetEquipmentItemByID(newEquipmentID);
+
+            if (equipment != null) {
+                player.characterInventoryManager.currentHelmetEquipment = equipment as HelmetEquipment;
+            } else {
+                player.characterInventoryManager.currentHelmetEquipment = null;
+            }
+            player.playerEquipmentManager.EquipAllEquipmentModels();
+        }
+        public void OnTorsoEquipmentChange(int oldEquipmentID, int newEquipmentID) {
+            if (player.IsOwner) return;
+            EquipmentItem equipment = WorldItemDatabase.instance.GetEquipmentItemByID(newEquipmentID);
+
+            if (equipment != null) {
+                player.characterInventoryManager.currentTorsoEquipment = equipment as TorsoEquipment;
+            } else {
+                player.characterInventoryManager.currentTorsoEquipment = null;
+            }
+            player.playerEquipmentManager.EquipAllEquipmentModels();
+        }
+        public void OnGuntletEquipmentChange(int oldEquipmentID, int newEquipmentID) {
+            if (player.IsOwner) return;
+            EquipmentItem equipment = WorldItemDatabase.instance.GetEquipmentItemByID(newEquipmentID);
+
+            if (equipment != null) {
+                player.characterInventoryManager.currentGuntletEquipment = equipment as GuntletEquipment;
+            } else {
+                player.characterInventoryManager.currentGuntletEquipment = null;
+            }
+            player.playerEquipmentManager.EquipAllEquipmentModels();
+        }
+        public void OnLegEquipmentChange(int oldEquipmentID, int newEquipmentID) {
+            if (player.IsOwner) return;
+            EquipmentItem equipment = WorldItemDatabase.instance.GetEquipmentItemByID(newEquipmentID);
+
+            if (equipment != null) {
+                player.characterInventoryManager.currentLegEquipment = equipment as LegEquipment;
+            } else {
+                player.characterInventoryManager.currentLegEquipment = null;
+            }
+            player.playerEquipmentManager.EquipAllEquipmentModels();
+        }
     }
 }


### PR DESCRIPTION
방어구 동기화

# CharacterNetworkManager
- 현재 캐릭터의 머리, 몸, 손, 다리 갑옷의 식별번호를 저장할 네트워크 변수

# PlayerNetworkManager
- 갑옷을 변경하는 기능이 플레이어 한테만 있기 때문에 실질적인 메서드를 여기서 구현
- 각 부위별로 이 캐릭터의 주인이 현재 클라이언트가 아니라면 인수로 넘겨받은 식별번호로 갑옷을 교체

# PlayerEquipmentManager
- 플레이어가 모든 부위의 갑옷을 장착할 때
- 해당 부위가 비어있지 않다면 네트워크 변수들에 현재 갑옷의 식별번호를 전달
- 해당 부위가 비어있다면 네트워크 변수에 -1 전달

# PlayerManager
- 네트워크의 부위별 갑옷 변수들의 OnValueChanged 이벤트에 부위별 갑옷읠 변경하는 함수를 핸들러로 연결
- 네트워크에 접속했을 당시의 다른 클라이언트들 상태를 바로 반영해주기 위해 각 부위별 갑옷 교체 함수들을 호출