### PR TITLE
Netcode

### DIFF
--- a/Assets/Scripts/Player/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Player/Managers/PlayerManager.cs
@@ -99,6 +99,10 @@ namespace SoulsLike {
             }
             playerNetworkManager.currentRightWeaponID.OnValueChanged += playerNetworkManager.OnRightWeaponChange;
             playerNetworkManager.currentLeftWeaponID.OnValueChanged += playerNetworkManager.OnLeftWeaponChange;
+            playerNetworkManager.currentHeadEquipmentID.OnValueChanged += playerNetworkManager.OnHeadEquipmentChange;
+            playerNetworkManager.currentTorsoEquipmentID.OnValueChanged += playerNetworkManager.OnTorsoEquipmentChange;
+            playerNetworkManager.currentGuntletEquipmentID.OnValueChanged += playerNetworkManager.OnGuntletEquipmentChange;
+            playerNetworkManager.currentLegEquipmentID.OnValueChanged += playerNetworkManager.OnLegEquipmentChange;
         }
 
         protected override void Update() {
@@ -389,6 +393,10 @@ namespace SoulsLike {
             Debug.Log("다른 플레이어 캐릭터 로드");
             player.playerNetworkManager.OnRightWeaponChange(0, player.playerNetworkManager.currentRightWeaponID.Value);
             player.playerNetworkManager.OnLeftWeaponChange(0, player.playerNetworkManager.currentLeftWeaponID.Value);
+            player.playerNetworkManager.OnHeadEquipmentChange(0, player.playerNetworkManager.currentHeadEquipmentID.Value);
+            player.playerNetworkManager.OnTorsoEquipmentChange(0, player.playerNetworkManager.currentTorsoEquipmentID.Value);
+            player.playerNetworkManager.OnGuntletEquipmentChange(0, player.playerNetworkManager.currentGuntletEquipmentID.Value);
+            player.playerNetworkManager.OnLegEquipmentChange(0, player.playerNetworkManager.currentLegEquipmentID.Value);
         }
     }
 }


### PR DESCRIPTION
방어구 동기화

# CharacterNetworkManager
- 현재 캐릭터의 머리, 몸, 손, 다리 갑옷의 식별번호를 저장할 네트워크 변수

# PlayerNetworkManager
- 갑옷을 변경하는 기능이 플레이어 한테만 있기 때문에 실질적인 메서드를 여기서 구현
- 각 부위별로 이 캐릭터의 주인이 현재 클라이언트가 아니라면 인수로 넘겨받은 식별번호로 갑옷을 교체

# PlayerEquipmentManager
- 플레이어가 모든 부위의 갑옷을 장착할 때
- 해당 부위가 비어있지 않다면 네트워크 변수들에 현재 갑옷의 식별번호를 전달
- 해당 부위가 비어있다면 네트워크 변수에 -1 전달

# PlayerManager
- 네트워크의 부위별 갑옷 변수들의 OnValueChanged 이벤트에 부위별 갑옷읠 변경하는 함수를 핸들러로 연결
- 네트워크에 접속했을 당시의 다른 클라이언트들 상태를 바로 반영해주기 위해 각 부위별 갑옷 교체 함수들을 호출